### PR TITLE
fix: Index returns first matching item per key, not last

### DIFF
--- a/query/preload.go
+++ b/query/preload.go
@@ -132,7 +132,10 @@ func GroupBy[T any, K comparable](items []T, key func(T) K) map[K][]T {
 func Index[T any, K comparable](items []T, key func(T) K) map[K]T {
 	m := make(map[K]T, len(items))
 	for _, item := range items {
-		m[key(item)] = item
+		k := key(item)
+		if _, exists := m[k]; !exists {
+			m[k] = item
+		}
 	}
 	return m
 }


### PR DESCRIPTION
## Summary
- Fixes `Index` in `query/preload.go` to use first-wins semantics as documented
- Previously, the map entry was overwritten on each iteration, returning the last match
- Now checks `if _, exists := m[k]; !exists` before setting, preserving the first match

## Test plan
- [ ] Verify `Index` returns the first item when duplicate keys exist
- [ ] Existing preload queries still work correctly (most use unique keys anyway)

Fixes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)