### PR TITLE
docs: replace G-Rizzle references and rename GRiz* to Griz*

### DIFF
--- a/.serena/memories/project/overview.md
+++ b/.serena/memories/project/overview.md
@@ -32,7 +32,7 @@ kit/              — Migration tooling (stubbed directories, not yet implemente
 ## Key Design Decisions
 1. **Immutable query builders** — every method returns a copy, safe to share/extend
 2. **ColBase embedding** — all column types embed ColBase for common IsNull/IsNotNull/Asc/Desc
-3. **TableSource interface** — GRizTableName() + GRizTableAlias() — implemented by generated table types
+3. **TableSource interface** — GrizTableName() + GrizTableAlias() — implemented by generated table types
 4. **Nil-safe And/Or** — nil expressions silently dropped, key for dynamic WHERE
 5. **BuildContext** — carries dialect + accumulates args, threaded through all ToSQL calls
 6. **structToColVals reflection** — Insert/Update accept db-tagged structs; nil pointers = omit

--- a/dialect/dialect.go
+++ b/dialect/dialect.go
@@ -1,5 +1,5 @@
 // Package dialect defines the SQL dialect interface and built-in implementations.
-// All SQL generation in G-rizzle is dialect-aware, allowing the same query builder
+// All SQL generation in Grizzle is dialect-aware, allowing the same query builder
 // to produce correct SQL for PostgreSQL, MySQL, and SQLite.
 package dialect
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -87,8 +87,8 @@ type UsersTable struct {
     DeletedAt expr.TimestampColumn
 }
 
-func (UsersTable) GRizTableName() string  { return "users" }
-func (UsersTable) GRizTableAlias() string { return "users" }
+func (UsersTable) GrizTableName() string  { return "users" }
+func (UsersTable) GrizTableAlias() string { return "users" }
 
 var UsersT = UsersTable{
     ID:        expr.UUIDColumn{ColBase: expr.ColBase{TableAlias: "users", ColName: "id"}},

--- a/driver/pgx/db.go
+++ b/driver/pgx/db.go
@@ -1,4 +1,4 @@
-// Package pgx provides the G-rizzle database adapter for jackc/pgx v5.
+// Package pgx provides the Grizzle database adapter for jackc/pgx v5.
 // It wraps pgxpool.Pool and exposes a transaction helper, keeping the
 // query builder and execution layer cleanly separated.
 //
@@ -28,7 +28,7 @@ import (
 	"github.com/sofired/grizzle/query"
 )
 
-// DB wraps a pgxpool.Pool and provides G-rizzle integration helpers.
+// DB wraps a pgxpool.Pool and provides Grizzle integration helpers.
 type DB struct {
 	pool *pgxpool.Pool
 }
@@ -145,7 +145,7 @@ func ScanOneOpt[T any](rows pgx.Rows, err error) (*T, error) {
 // Transactions
 // -------------------------------------------------------------------
 
-// Tx wraps a pgx.Tx with G-rizzle helpers.
+// Tx wraps a pgx.Tx with Grizzle helpers.
 type Tx struct {
 	tx pgx.Tx
 }

--- a/driver/sql/db.go
+++ b/driver/sql/db.go
@@ -1,4 +1,4 @@
-// Package sql provides G-rizzle integration for database/sql-based drivers
+// Package sql provides Grizzle integration for database/sql-based drivers
 // (MySQL via go-sql-driver/mysql, SQLite via mattn/go-sqlite3, and any other
 // driver that uses the standard database/sql interface).
 //
@@ -52,7 +52,7 @@ import (
 // It mirrors the sentinel error from database/sql.
 var ErrNoRows = sql.ErrNoRows
 
-// DB wraps a *sql.DB together with its dialect and provides G-rizzle helpers.
+// DB wraps a *sql.DB together with its dialect and provides Grizzle helpers.
 type DB struct {
 	db *sql.DB
 	d  dialect.Dialect
@@ -205,7 +205,7 @@ func ScanOneOpt[T any](rows *sql.Rows, err error) (*T, error) {
 // Transactions
 // -------------------------------------------------------------------
 
-// Tx wraps a *sql.Tx with G-rizzle helpers.
+// Tx wraps a *sql.Tx with Grizzle helpers.
 type Tx struct {
 	tx *sql.Tx
 	d  dialect.Dialect

--- a/driver/sql/db_test.go
+++ b/driver/sql/db_test.go
@@ -19,8 +19,8 @@ import (
 
 type usersTable struct{ expr.ColBase }
 
-func (usersTable) GRizTableName() string  { return "users" }
-func (usersTable) GRizTableAlias() string { return "users" }
+func (usersTable) GrizTableName() string  { return "users" }
+func (usersTable) GrizTableAlias() string { return "users" }
 
 var (
 	usersT  = usersTable{}

--- a/expr/context.go
+++ b/expr/context.go
@@ -1,4 +1,4 @@
-// Package expr provides the type-safe expression system for G-rizzle.
+// Package expr provides the type-safe expression system for Grizzle.
 // Column types (UUIDColumn, StringColumn, etc.) expose only the operators
 // that are valid for their SQL type, producing compile-time errors when
 // mismatched types are compared.

--- a/gen/codegen/codegen.go
+++ b/gen/codegen/codegen.go
@@ -1,4 +1,4 @@
-// Package codegen converts parsed G-rizzle schema definitions into Go source
+// Package codegen converts parsed Grizzle schema definitions into Go source
 // files containing typed table handles and model structs.
 package codegen
 
@@ -183,8 +183,8 @@ type {{.TableTypeName}} struct {
 {{- end}}
 }
 
-func ({{.TableTypeName}}) GRizTableName() string  { return {{quote .TableName}} }
-func ({{.TableTypeName}}) GRizTableAlias() string { return {{quote .TableName}} }
+func ({{.TableTypeName}}) GrizTableName() string  { return {{quote .TableName}} }
+func ({{.TableTypeName}}) GrizTableAlias() string { return {{quote .TableName}} }
 
 // {{.SingletonName}} is the singleton handle for the {{.TableName}} table.
 var {{.SingletonName}} = {{.TableTypeName}}{

--- a/gen/codegen/codegen_test.go
+++ b/gen/codegen/codegen_test.go
@@ -59,8 +59,8 @@ func TestGenerateTable_Smoke(t *testing.T) {
 	// type name and field name separately rather than "Field Type" as one string.
 	checks := []string{
 		"type UsersTable struct",
-		"func (UsersTable) GRizTableName() string",
-		"func (UsersTable) GRizTableAlias() string",
+		"func (UsersTable) GrizTableName() string",
+		"func (UsersTable) GrizTableAlias() string",
 		"var UsersT = UsersTable{",
 		"type UserSelect struct",
 		"type UserInsert struct",

--- a/gen/parser/chain.go
+++ b/gen/parser/chain.go
@@ -1,4 +1,4 @@
-// Package parser provides AST-based parsing of G-rizzle schema definitions.
+// Package parser provides AST-based parsing of Grizzle schema definitions.
 // It reads Go source files containing pg.Table(...) declarations and extracts
 // structured TableDef information without executing the schema code.
 package parser

--- a/internal/testschema/schema.go
+++ b/internal/testschema/schema.go
@@ -1,10 +1,10 @@
-// Package testschema defines a small representative schema used in G-rizzle's
+// Package testschema defines a small representative schema used in Grizzle's
 // own tests. It mirrors the patterns from the uncloak-identity project:
 // soft-delete, partial indexes, composite FKs, JSONB columns, UUID PKs.
 //
 // This package plays a dual role:
 //  1. It's used by tests to verify SQL generation without a live database.
-//  2. It serves as the canonical example of the G-rizzle schema DSL.
+//  2. It serves as the canonical example of the Grizzle schema DSL.
 package testschema
 
 import (
@@ -77,8 +77,8 @@ type RealmsTable struct {
 	UpdatedAt   expr.TimestampColumn
 }
 
-func (RealmsTable) GRizTableName() string  { return "realms" }
-func (RealmsTable) GRizTableAlias() string { return "realms" }
+func (RealmsTable) GrizTableName() string  { return "realms" }
+func (RealmsTable) GrizTableAlias() string { return "realms" }
 
 // RealmsT is the singleton table handle used in queries.
 var RealmsT = RealmsTable{
@@ -106,8 +106,8 @@ type UsersTable struct {
 	PurgedAt      expr.TimestampColumn
 }
 
-func (UsersTable) GRizTableName() string  { return "users" }
-func (UsersTable) GRizTableAlias() string { return "users" }
+func (UsersTable) GrizTableName() string  { return "users" }
+func (UsersTable) GrizTableAlias() string { return "users" }
 
 var UsersT = UsersTable{
 	ID:            expr.UUIDColumn{ColBase: expr.ColBase{TableAlias: "users", ColName: "id"}},

--- a/kit/migrate.go
+++ b/kit/migrate.go
@@ -13,7 +13,7 @@ import (
 	pg "github.com/sofired/grizzle/schema/pg"
 )
 
-// MigrationsTable is the name of the history table G-rizzle creates to track
+// MigrationsTable is the name of the history table Grizzle creates to track
 // applied migrations.
 const MigrationsTable = "_grizzle_migrations"
 

--- a/kit/snapshot.go
+++ b/kit/snapshot.go
@@ -1,4 +1,4 @@
-// Package kit provides G-rizzle's migration tooling: schema snapshots, diffing,
+// Package kit provides Grizzle's migration tooling: schema snapshots, diffing,
 // SQL generation, and schema push. It is the Go equivalent of Drizzle Kit.
 //
 // Typical usage (library mode — user writes their own migrate entrypoint):

--- a/query/delete.go
+++ b/query/delete.go
@@ -55,7 +55,7 @@ func (b *DeleteBuilder) Build(d dialect.Dialect) (string, []any) {
 	var sb strings.Builder
 
 	sb.WriteString("DELETE FROM ")
-	sb.WriteString(ctx.Quote(b.table.GRizTableName()))
+	sb.WriteString(ctx.Quote(b.table.GrizTableName()))
 
 	sb.WriteString(buildWhere(ctx, b.where))
 

--- a/query/insert.go
+++ b/query/insert.go
@@ -195,7 +195,7 @@ func (b *InsertBuilder) Build(d dialect.Dialect) (string, []any) {
 	} else {
 		sb.WriteString("INSERT INTO ")
 	}
-	sb.WriteString(ctx.Quote(b.table.GRizTableName()))
+	sb.WriteString(ctx.Quote(b.table.GrizTableName()))
 
 	// Column list
 	sb.WriteString(" (")

--- a/query/preload.go
+++ b/query/preload.go
@@ -9,7 +9,7 @@ import (
 // Eager loading — batch query helpers and result collectors
 // -------------------------------------------------------------------
 //
-// G-rizzle's approach to N+1 prevention is explicit and composable:
+// Grizzle's approach to N+1 prevention is explicit and composable:
 //
 //  1. Load primary rows with a regular SELECT.
 //  2. Pluck FK values from those rows.

--- a/query/query.go
+++ b/query/query.go
@@ -1,4 +1,4 @@
-// Package query provides the G-rizzle fluent query builder.
+// Package query provides the Grizzle fluent query builder.
 // All builders are safe for concurrent use after construction — they are
 // immutable value types; each method returns a new copy.
 //
@@ -26,11 +26,11 @@ import (
 // TableSource is implemented by generated table types and can appear in
 // FROM and JOIN clauses.
 type TableSource interface {
-	// GRizTableName returns the SQL table name (without schema qualification).
-	GRizTableName() string
-	// GRizTableAlias returns the alias to use for this table in a query.
-	// Usually the same as GRizTableName unless the table has been aliased.
-	GRizTableAlias() string
+	// GrizTableName returns the SQL table name (without schema qualification).
+	GrizTableName() string
+	// GrizTableAlias returns the alias to use for this table in a query.
+	// Usually the same as GrizTableName unless the table has been aliased.
+	GrizTableAlias() string
 }
 
 // -------------------------------------------------------------------

--- a/query/query_test.go
+++ b/query/query_test.go
@@ -587,8 +587,8 @@ func TestRelation_BelongsTo_Fields(t *testing.T) {
 	if rel.Name != "realm" {
 		t.Errorf("name: got %q, want %q", rel.Name, "realm")
 	}
-	if rel.Table.GRizTableName() != "realms" {
-		t.Errorf("table: got %q, want %q", rel.Table.GRizTableName(), "realms")
+	if rel.Table.GrizTableName() != "realms" {
+		t.Errorf("table: got %q, want %q", rel.Table.GrizTableName(), "realms")
 	}
 	if rel.On == nil {
 		t.Error("On expression must not be nil")
@@ -603,8 +603,8 @@ func TestRelation_HasMany_Fields(t *testing.T) {
 	if rel.Name != "users" {
 		t.Errorf("name: got %q, want %q", rel.Name, "users")
 	}
-	if rel.Table.GRizTableName() != "users" {
-		t.Errorf("table: got %q, want %q", rel.Table.GRizTableName(), "users")
+	if rel.Table.GrizTableName() != "users" {
+		t.Errorf("table: got %q, want %q", rel.Table.GrizTableName(), "users")
 	}
 }
 

--- a/query/select.go
+++ b/query/select.go
@@ -130,8 +130,8 @@ func CTERef(name string) TableSource { return cteTableSource{name: name} }
 
 type cteTableSource struct{ name string }
 
-func (c cteTableSource) GRizTableName() string  { return c.name }
-func (c cteTableSource) GRizTableAlias() string { return c.name }
+func (c cteTableSource) GrizTableName() string  { return c.name }
+func (c cteTableSource) GrizTableAlias() string { return c.name }
 
 // From sets the primary table.
 func (b *SelectBuilder) From(t TableSource) *SelectBuilder {
@@ -306,10 +306,10 @@ func (b *SelectBuilder) buildWith(ctx *expr.BuildContext) string {
 			sb.WriteString(") AS ")
 			sb.WriteString(ctx.Quote(sq.alias))
 		} else {
-			sb.WriteString(ctx.Quote(b.from.GRizTableName()))
-			if b.from.GRizTableAlias() != b.from.GRizTableName() {
+			sb.WriteString(ctx.Quote(b.from.GrizTableName()))
+			if b.from.GrizTableAlias() != b.from.GrizTableName() {
 				sb.WriteString(" AS ")
-				sb.WriteString(ctx.Quote(b.from.GRizTableAlias()))
+				sb.WriteString(ctx.Quote(b.from.GrizTableAlias()))
 			}
 		}
 	}
@@ -319,10 +319,10 @@ func (b *SelectBuilder) buildWith(ctx *expr.BuildContext) string {
 		sb.WriteString(" ")
 		sb.WriteString(string(j.kind))
 		sb.WriteString(" ")
-		sb.WriteString(ctx.Quote(j.table.GRizTableName()))
-		if j.table.GRizTableAlias() != j.table.GRizTableName() {
+		sb.WriteString(ctx.Quote(j.table.GrizTableName()))
+		if j.table.GrizTableAlias() != j.table.GrizTableName() {
 			sb.WriteString(" AS ")
-			sb.WriteString(ctx.Quote(j.table.GRizTableAlias()))
+			sb.WriteString(ctx.Quote(j.table.GrizTableAlias()))
 		}
 		if j.on != nil {
 			sb.WriteString(" ON ")

--- a/query/subquery.go
+++ b/query/subquery.go
@@ -53,12 +53,12 @@ func FromSubquery(sub *SelectBuilder, alias string) *SubquerySource {
 	return &SubquerySource{sub: sub, alias: alias}
 }
 
-// GRizTableName satisfies TableSource. Returns the alias (used as the table
+// GrizTableName satisfies TableSource. Returns the alias (used as the table
 // reference in column expressions against this subquery).
-func (s *SubquerySource) GRizTableName() string { return s.alias }
+func (s *SubquerySource) GrizTableName() string { return s.alias }
 
-// GRizTableAlias satisfies TableSource.
-func (s *SubquerySource) GRizTableAlias() string { return s.alias }
+// GrizTableAlias satisfies TableSource.
+func (s *SubquerySource) GrizTableAlias() string { return s.alias }
 
 // -------------------------------------------------------------------
 // internal expression types

--- a/query/update.go
+++ b/query/update.go
@@ -87,7 +87,7 @@ func (b *UpdateBuilder) Build(d dialect.Dialect) (string, []any) {
 	var sb strings.Builder
 
 	sb.WriteString("UPDATE ")
-	sb.WriteString(ctx.Quote(b.table.GRizTableName()))
+	sb.WriteString(ctx.Quote(b.table.GrizTableName()))
 	sb.WriteString(" SET ")
 
 	// Collect all SET clauses: explicit sets + struct sets

--- a/schema/pg/column.go
+++ b/schema/pg/column.go
@@ -1,4 +1,4 @@
-// Package pg provides the PostgreSQL schema definition DSL for G-rizzle.
+// Package pg provides the PostgreSQL schema definition DSL for Grizzle.
 // Use it to declare your database schema in Go; the grizzle code generator
 // reads these declarations to produce typed query helpers and migration snapshots.
 //


### PR DESCRIPTION
## Summary

- Replace all remaining `G-Rizzle`/`G-rizzle` references in package docs, comments, and README with `Grizzle`
- Rename exported `TableSource` interface methods:
  - `GRizTableName()` → `GrizTableName()`
  - `GRizTableAlias()` → `GrizTableAlias()`
- Update all implementations, call sites, codegen template, and test assertions

> ⚠️ **Breaking change**: `GrizTableName` and `GrizTableAlias` are exported interface methods on `TableSource`. Any user-generated code (via `grizzle gen`) must be regenerated — the codegen template has been updated so regeneration produces the correct output automatically.

Closes #24

## Test plan

- [x] `go test ./...` passes
- [ ] CI checks pass