### PR TITLE
chore: remove CheckBuilder and setReferences stub code

### DIFF
--- a/schema/pg/column.go
+++ b/schema/pg/column.go
@@ -91,15 +91,6 @@ func (b *colBuilder) setDefault(expr string) {
 	b.def.HasDefault = true
 	b.def.DefaultExpr = expr
 }
-func (b *colBuilder) setReferences(table, col string, onDelete, onUpdate FKAction) { //nolint:unused
-	b.def.References = &FKRef{
-		Table:    table,
-		Column:   col,
-		OnDelete: onDelete,
-		OnUpdate: onUpdate,
-	}
-}
-
 func (b *colBuilder) setPrimaryKey() {
 	b.def.PrimaryKey = true
 	b.def.NotNull = true    // PK is implicitly NOT NULL
@@ -336,7 +327,6 @@ func (b *TimestampBuilder) Build(name string) ColumnDef { return b.build(name) }
 // JSONBBuilder builds a jsonb column definition.
 type JSONBBuilder struct {
 	colBuilder
-	goTypeOverride string //nolint:unused
 }
 
 // JSONB starts a jsonb column.

--- a/schema/pg/constraint.go
+++ b/schema/pg/constraint.go
@@ -96,9 +96,6 @@ func (b *IndexBuilder) Build() Constraint { return b.c }
 // Check builder
 // -------------------------------------------------------------------
 
-// CheckBuilder builds a CHECK constraint.
-type CheckBuilder struct{ c Constraint } //nolint:unused
-
 // Check creates a CHECK constraint with the given name and raw SQL expression.
 func Check(name, expr string) Constraint {
 	return Constraint{Kind: KindCheck, Name: name, CheckExpr: expr}


### PR DESCRIPTION
Closes #13

## Summary
- Removed the `CheckBuilder` struct in `schema/pg/constraint.go` — it had no methods and was never used; the `Check()` function already returns a `Constraint` directly without needing a builder type
- Removed `colBuilder.setReferences` in `schema/pg/column.go` — all typed builders (`UUIDBuilder`, `VarcharBuilder`, `IntegerBuilder`) already implement `References` inline, making this shared helper redundant
- Removed the `goTypeOverride` field from `JSONBBuilder` — also unused and suppressed with `//nolint:unused`; the existing `Type()` method correctly sets `def.JsonbGoType` directly

All three items were dead code hidden behind `//nolint:unused` suppressions with no concrete use case. No functionality is changed.