### PR TITLE
fix: Diff() output ordering is non-deterministic due to map iteration

### DIFF
--- a/kit/diff.go
+++ b/kit/diff.go
@@ -1,6 +1,8 @@
 package kit
 
 import (
+	"sort"
+
 	pg "github.com/sofired/grizzle/schema/pg"
 )
 
@@ -46,7 +48,8 @@ func Diff(old, new Snapshot) []Change {
 	var changes []Change
 
 	// Phase 1: new tables not in old → CREATE TABLE.
-	for name := range new.Tables {
+	newNames := sortedKeys(new.Tables)
+	for _, name := range newNames {
 		if _, exists := old.Tables[name]; !exists {
 			changes = append(changes, Change{
 				Kind:      ChangeCreateTable,
@@ -58,7 +61,8 @@ func Diff(old, new Snapshot) []Change {
 	}
 
 	// Phase 2: tables present in both → diff columns and constraints.
-	for name, newT := range new.Tables {
+	for _, name := range newNames {
+		newT := new.Tables[name]
 		oldT, exists := old.Tables[name]
 		if !exists {
 			continue // handled above
@@ -67,7 +71,7 @@ func Diff(old, new Snapshot) []Change {
 	}
 
 	// Phase 3: tables in old but not new → DROP TABLE.
-	for name := range old.Tables {
+	for _, name := range sortedKeys(old.Tables) {
 		if _, exists := new.Tables[name]; !exists {
 			changes = append(changes, Change{
 				Kind:      ChangeDropTable,
@@ -201,6 +205,16 @@ func constraintMap(cons []pg.Constraint) map[string]pg.Constraint {
 		m[c.Name] = c
 	}
 	return m
+}
+
+// sortedKeys returns the keys of a map[string]*TableSnap in ascending order.
+func sortedKeys(m map[string]*TableSnap) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 func constraintsEqual(a, b pg.Constraint) bool {

--- a/kit/kit_test.go
+++ b/kit/kit_test.go
@@ -169,6 +169,49 @@ func TestDiff_DropTable(t *testing.T) {
 	}
 }
 
+func TestDiff_DeterministicOrdering(t *testing.T) {
+	// Use a schema with several tables to maximise the chance of exposing
+	// map-iteration non-determinism if it were still present.
+	postsDef := pg.Table("posts",
+		pg.C("id", pg.UUID().PrimaryKey().DefaultRandom()),
+		pg.C("title", pg.Varchar(255).NotNull()),
+	).Build()
+	commentsDef := pg.Table("comments",
+		pg.C("id", pg.UUID().PrimaryKey().DefaultRandom()),
+		pg.C("body", pg.Text().NotNull()),
+	).Build()
+	tagsDef := pg.Table("tags",
+		pg.C("id", pg.UUID().PrimaryKey().DefaultRandom()),
+		pg.C("name", pg.Varchar(100).NotNull()),
+	).Build()
+
+	old := kit.EmptySnapshot()
+	new := kit.FromDefs(realmsDef, usersDef, postsDef, commentsDef, tagsDef)
+
+	// Call Diff many times and assert each result is identical.
+	const iterations = 50
+	first := kit.Diff(old, new)
+	for i := 1; i < iterations; i++ {
+		got := kit.Diff(old, new)
+		if len(got) != len(first) {
+			t.Fatalf("iteration %d: length mismatch: got %d, want %d", i, len(got), len(first))
+		}
+		for j := range first {
+			if got[j] != first[j] {
+				t.Fatalf("iteration %d: change[%d] differs:\n  got  %+v\n  want %+v", i, j, got[j], first[j])
+			}
+		}
+	}
+
+	// Additionally assert the order is the sorted alphabetical order we expect.
+	wantNames := []string{"comments", "posts", "realms", "tags", "users"}
+	for idx, want := range wantNames {
+		if first[idx].TableName != want {
+			t.Errorf("change[%d]: got table %q, want %q", idx, first[idx].TableName, want)
+		}
+	}
+}
+
 func TestDiff_AlterColumnType(t *testing.T) {
 	oldDef := pg.Table("t", pg.C("code", pg.Varchar(50).NotNull())).Build()
 	newDef := pg.Table("t", pg.C("code", pg.Varchar(100).NotNull())).Build()


### PR DESCRIPTION
Closes #8

## Summary
- Sort table names before iterating in all three phases of `Diff()` using a new `sortedKeys` helper
- Add `TestDiff_DeterministicOrdering` that calls `Diff()` 50 times across a 5-table schema and asserts identical change ordering on every call, plus verifies alphabetical table order