### PR TITLE
chore: pin all GitHub Actions to commit SHAs to mitigate supply chain risk

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,9 @@ jobs:
         go: ["1.24", "1.25", "1.26"]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           go-version: ${{ matrix.go }}
 
@@ -33,24 +33,24 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
           go-version: "1.24"
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9
         with:
-          version: latest
+          version: v2.11.3
 
   vuln:
     name: Vulnerability check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
-      - uses: golang/govulncheck-action@v1
+      - uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1
         with:
           go-version-input: "stable"
           go-package: ./...

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -22,11 +22,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: 20
           cache: npm
@@ -40,7 +40,7 @@ jobs:
           DOCS_BASE: /grizzle/
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4
         with:
           path: docs/.vitepress/dist
 
@@ -53,4 +53,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,11 +12,11 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2
         with:
           generate_release_notes: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,7 +14,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/stale@v10
+      - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10
         with:
           stale-issue-message: >
             This issue has been open for 60 days with no activity. It will be


### PR DESCRIPTION
Closes #27

## Summary
- Pin all third-party GitHub Actions to full commit SHAs across all four workflows (`ci.yml`, `release.yml`, `stale.yml`, `deploy-docs.yml`)
- Add version comments for readability (e.g. `# v6`)
- Pin `golangci-lint` version from `latest` to `v2.11.3`
- Update `actions/stale` to v10 (Dependabot bump merged separately in #28) with SHA pin

## Actions pinned
| Action | Version | SHA |
|--------|---------|-----|
| `actions/checkout` | v6 | `de0fac2e` |
| `actions/checkout` | v5 | `93cb6efe` |
| `actions/setup-go` | v6 | `4b73464b` |
| `golangci/golangci-lint-action` | v9 | `1e7e51e7` |
| `golang/govulncheck-action` | v1 | `b625fbe0` |
| `softprops/action-gh-release` | v2 | `a06a81a0` |
| `actions/stale` | v10 | `b5d41d4e` |
| `actions/setup-node` | v6 | `53b83947` |
| `actions/upload-pages-artifact` | v4 | `7b1f4a76` |
| `actions/deploy-pages` | v4 | `d6db9016` |

## Dependabot
Dependabot is already configured for the `github-actions` ecosystem and will keep these SHA pins current automatically.

## Notes
- Rebased on main after `actions/stale` was bumped from v9 to v10 by Dependabot (#28). Updated the SHA pin from v9 to v10.