### PR TITLE
feat: DISTINCT ON support for PostgreSQL SELECT

### DIFF
--- a/expr/agg.go
+++ b/expr/agg.go
@@ -20,10 +20,8 @@ type AggExpr struct {
 	alias    string // optional AS alias (for SELECT only)
 }
 
-// ToSQL renders the aggregate function call, including AS alias when set.
-// This is the form used in SELECT lists. For HAVING/ORDER BY, create the
-// aggregate without As() so no alias is emitted.
-func (a AggExpr) ToSQL(ctx *BuildContext) string {
+// renderCore renders the aggregate function call without any alias.
+func (a AggExpr) renderCore(ctx *BuildContext) string {
 	var arg string
 	if a.col == nil {
 		arg = "*"
@@ -33,15 +31,25 @@ func (a AggExpr) ToSQL(ctx *BuildContext) string {
 	if a.distinct {
 		arg = "DISTINCT " + arg
 	}
-	result := a.fn + "(" + arg + ")"
+	return a.fn + "(" + arg + ")"
+}
+
+// ToSQL renders the aggregate function call, including AS alias when set.
+// This is the form used in SELECT lists. For HAVING/ORDER BY, create the
+// aggregate without As() so no alias is emitted.
+func (a AggExpr) ToSQL(ctx *BuildContext) string {
+	result := a.renderCore(ctx)
 	if a.alias != "" {
 		result += " AS " + ctx.Quote(a.alias)
 	}
 	return result
 }
 
+// ToSQLBare implements BareExpression. Renders the aggregate call without any alias.
+func (a AggExpr) ToSQLBare(ctx *BuildContext) string { return a.renderCore(ctx) }
+
 // colRef implements colRefer so AggExpr can be embedded in OrderExpr.
-func (a AggExpr) colRef(ctx *BuildContext) string { return a.ToSQL(ctx) }
+func (a AggExpr) colRef(ctx *BuildContext) string { return a.renderCore(ctx) }
 
 // ColumnName implements SelectableColumn. Returns the alias if set, otherwise
 // the lower-case function name.

--- a/expr/case.go
+++ b/expr/case.go
@@ -55,8 +55,8 @@ func (c *CaseExpr) As(alias string) *CaseExpr {
 	return &cp
 }
 
-// ToSQL renders the CASE expression.
-func (c *CaseExpr) ToSQL(ctx *BuildContext) string {
+// renderCore renders the CASE expression without any alias.
+func (c *CaseExpr) renderCore(ctx *BuildContext) string {
 	var sb strings.Builder
 	sb.WriteString("CASE")
 	for _, w := range c.whens {
@@ -70,15 +70,23 @@ func (c *CaseExpr) ToSQL(ctx *BuildContext) string {
 		sb.WriteString(c.else_.ToSQL(ctx))
 	}
 	sb.WriteString(" END")
-	if c.alias != "" {
-		sb.WriteString(" AS ")
-		sb.WriteString(ctx.Quote(c.alias))
-	}
 	return sb.String()
 }
 
+// ToSQL renders the CASE expression.
+func (c *CaseExpr) ToSQL(ctx *BuildContext) string {
+	s := c.renderCore(ctx)
+	if c.alias != "" {
+		s += " AS " + ctx.Quote(c.alias)
+	}
+	return s
+}
+
+// ToSQLBare implements BareExpression. Renders the CASE expression without any alias.
+func (c *CaseExpr) ToSQLBare(ctx *BuildContext) string { return c.renderCore(ctx) }
+
 // colRef implements colRefer so CaseExpr can appear in OrderExpr and binary expressions.
-func (c *CaseExpr) colRef(ctx *BuildContext) string { return c.ToSQL(ctx) }
+func (c *CaseExpr) colRef(ctx *BuildContext) string { return c.renderCore(ctx) }
 
 // ColumnName implements SelectableColumn. Returns the alias if set, otherwise "case".
 func (c *CaseExpr) ColumnName() string {
@@ -153,8 +161,8 @@ func (c *SimpleCaseExpr) As(alias string) *SimpleCaseExpr {
 	return &cp
 }
 
-// ToSQL renders the simple CASE expression.
-func (c *SimpleCaseExpr) ToSQL(ctx *BuildContext) string {
+// renderCore renders the simple CASE expression without any alias.
+func (c *SimpleCaseExpr) renderCore(ctx *BuildContext) string {
 	var sb strings.Builder
 	sb.WriteString("CASE ")
 	sb.WriteString(c.subject.colRef(ctx))
@@ -169,14 +177,22 @@ func (c *SimpleCaseExpr) ToSQL(ctx *BuildContext) string {
 		sb.WriteString(c.else_.ToSQL(ctx))
 	}
 	sb.WriteString(" END")
-	if c.alias != "" {
-		sb.WriteString(" AS ")
-		sb.WriteString(ctx.Quote(c.alias))
-	}
 	return sb.String()
 }
 
-func (c *SimpleCaseExpr) colRef(ctx *BuildContext) string { return c.ToSQL(ctx) }
+// ToSQL renders the simple CASE expression.
+func (c *SimpleCaseExpr) ToSQL(ctx *BuildContext) string {
+	s := c.renderCore(ctx)
+	if c.alias != "" {
+		s += " AS " + ctx.Quote(c.alias)
+	}
+	return s
+}
+
+// ToSQLBare implements BareExpression. Renders the simple CASE expression without any alias.
+func (c *SimpleCaseExpr) ToSQLBare(ctx *BuildContext) string { return c.renderCore(ctx) }
+
+func (c *SimpleCaseExpr) colRef(ctx *BuildContext) string { return c.renderCore(ctx) }
 func (c *SimpleCaseExpr) ColumnName() string {
 	if c.alias != "" {
 		return c.alias

--- a/expr/expr.go
+++ b/expr/expr.go
@@ -12,6 +12,17 @@ type Expression interface {
 	ToSQL(ctx *BuildContext) string
 }
 
+// BareExpression is an optional extension of Expression for types that support
+// rendering without a SELECT alias. It is implemented by aliasable expression
+// types (FuncExpr, AggExpr, ArithExpr, CastExpr) and is used by the query
+// builder when a bare expression is required — for example, inside DISTINCT ON
+// (...), where PostgreSQL does not permit AS aliases.
+type BareExpression interface {
+	Expression
+	// ToSQLBare renders the expression without any AS alias suffix.
+	ToSQLBare(ctx *BuildContext) string
+}
+
 // -------------------------------------------------------------------
 // Logical combinators
 // -------------------------------------------------------------------

--- a/expr/fn.go
+++ b/expr/fn.go
@@ -79,6 +79,9 @@ func (f FuncExpr) ToSQL(ctx *BuildContext) string {
 	return s
 }
 
+// ToSQLBare implements BareExpression. Renders the function call without any alias.
+func (f FuncExpr) ToSQLBare(ctx *BuildContext) string { return f.renderCore(ctx) }
+
 // colRef implements colRefer (no alias — for use inside other expressions).
 func (f FuncExpr) colRef(ctx *BuildContext) string { return f.renderCore(ctx) }
 
@@ -156,6 +159,9 @@ func (a ArithExpr) ToSQL(ctx *BuildContext) string {
 	return s
 }
 
+// ToSQLBare implements BareExpression. Renders the arithmetic expression without any alias.
+func (a ArithExpr) ToSQLBare(ctx *BuildContext) string { return a.renderCore(ctx) }
+
 // colRef implements colRefer (no alias — for use inside other expressions).
 func (a ArithExpr) colRef(ctx *BuildContext) string { return a.renderCore(ctx) }
 
@@ -227,6 +233,9 @@ func (e CastExpr) ToSQL(ctx *BuildContext) string {
 	}
 	return s
 }
+
+// ToSQLBare implements BareExpression. Renders the CAST expression without any alias.
+func (e CastExpr) ToSQLBare(ctx *BuildContext) string { return e.renderCore(ctx) }
 
 func (e CastExpr) colRef(ctx *BuildContext) string { return e.renderCore(ctx) }
 func (e CastExpr) ColumnName() string {

--- a/expr/window.go
+++ b/expr/window.go
@@ -24,8 +24,8 @@ type WindowExpr struct {
 	alias       string             // optional AS alias
 }
 
-// ToSQL renders the window function including the OVER clause and optional alias.
-func (w WindowExpr) ToSQL(ctx *BuildContext) string {
+// renderCore renders the window function and OVER clause without any alias.
+func (w WindowExpr) renderCore(ctx *BuildContext) string {
 	var sb strings.Builder
 	sb.WriteString(w.fn)
 	sb.WriteString("(")
@@ -51,16 +51,23 @@ func (w WindowExpr) ToSQL(ctx *BuildContext) string {
 	}
 	sb.WriteString(strings.Join(parts, " "))
 	sb.WriteString(")")
-
-	if w.alias != "" {
-		sb.WriteString(" AS ")
-		sb.WriteString(ctx.Quote(w.alias))
-	}
 	return sb.String()
 }
 
+// ToSQL renders the window function including the OVER clause and optional alias.
+func (w WindowExpr) ToSQL(ctx *BuildContext) string {
+	s := w.renderCore(ctx)
+	if w.alias != "" {
+		s += " AS " + ctx.Quote(w.alias)
+	}
+	return s
+}
+
+// ToSQLBare implements BareExpression. Renders the window function without any alias.
+func (w WindowExpr) ToSQLBare(ctx *BuildContext) string { return w.renderCore(ctx) }
+
 // colRef implements colRefer so WindowExpr can appear in OrderExpr and binary expressions.
-func (w WindowExpr) colRef(ctx *BuildContext) string { return w.ToSQL(ctx) }
+func (w WindowExpr) colRef(ctx *BuildContext) string { return w.renderCore(ctx) }
 
 // ColumnName implements SelectableColumn. Returns the alias if set, otherwise
 // the lower-case function name.

--- a/query/query_test.go
+++ b/query/query_test.go
@@ -1585,6 +1585,60 @@ func TestSelect_DistinctOn_NoopOnSQLite(t *testing.T) {
 	}
 }
 
+func TestSelect_DistinctOn_AliasedFuncExprStripped(t *testing.T) {
+	// DISTINCT ON must not include AS alias — PostgreSQL rejects aliases inside
+	// DISTINCT ON (...). Aliased FuncExpr should render without the alias there.
+	upper := expr.Upper(ts.UsersT.Username).As("uname")
+	assertSQL(t, "DISTINCT ON aliased FuncExpr strips alias",
+		query.Select(upper).
+			From(ts.UsersT).
+			DistinctOn(upper).
+			OrderBy(ts.UsersT.Username.Asc()),
+		`SELECT DISTINCT ON (UPPER("users"."username")) UPPER("users"."username") AS "uname" FROM "users" ORDER BY "users"."username" ASC`,
+		nil,
+	)
+}
+
+func TestSelect_DistinctOn_AliasedAggExprStripped(t *testing.T) {
+	// Aliased AggExpr passed to DistinctOn must render without AS alias inside
+	// the DISTINCT ON (...) clause.
+	cnt := expr.CountCol(ts.UsersT.ID).As("cnt")
+	gotSQL, _ := query.Select(cnt).
+		From(ts.UsersT).
+		DistinctOn(cnt).
+		Build(dialect.Postgres)
+	const want = `SELECT DISTINCT ON (COUNT("users"."id")) COUNT("users"."id") AS "cnt" FROM "users"`
+	if gotSQL != want {
+		t.Errorf("DISTINCT ON aliased AggExpr SQL mismatch\n got:  %s\nwant: %s", gotSQL, want)
+	}
+}
+
+func TestSelect_DistinctOn_ZeroArgsIsNoop(t *testing.T) {
+	// DistinctOn() with zero arguments must be a no-op and must not clear a
+	// previously set Distinct() flag or any prior DistinctOn() state.
+
+	// Case 1: calling DistinctOn() after Distinct() must leave DISTINCT intact.
+	assertSQL(t, "DistinctOn() zero args after Distinct is no-op",
+		query.Select(ts.UsersT.ID).
+			From(ts.UsersT).
+			Distinct().
+			DistinctOn(), // zero args — should not clear DISTINCT
+		`SELECT DISTINCT "users"."id" FROM "users"`,
+		nil,
+	)
+
+	// Case 2: calling DistinctOn() after DistinctOn(col) must leave the original
+	// DISTINCT ON intact.
+	assertSQL(t, "DistinctOn() zero args after DistinctOn(col) is no-op",
+		query.Select(ts.UsersT.ID).
+			From(ts.UsersT).
+			DistinctOn(ts.UsersT.RealmID).
+			DistinctOn(), // zero args — should not clear DISTINCT ON
+		`SELECT DISTINCT ON ("users"."realm_id") "users"."id" FROM "users"`,
+		nil,
+	)
+}
+
 // -------------------------------------------------------------------
 // NULLS FIRST / NULLS LAST tests
 // -------------------------------------------------------------------

--- a/query/select.go
+++ b/query/select.go
@@ -79,6 +79,9 @@ func (b *SelectBuilder) Distinct() *SelectBuilder {
 //	// FROM "users"
 //	// ORDER BY "users"."realm_id" ASC, "users"."created_at" DESC
 func (b *SelectBuilder) DistinctOn(cols ...expr.SelectableColumn) *SelectBuilder {
+	if len(cols) == 0 {
+		return b
+	}
 	cp := *b
 	cp.distinct = false
 	cp.distinctOn = append([]expr.SelectableColumn(nil), cols...)
@@ -316,7 +319,7 @@ func (b *SelectBuilder) buildWith(ctx *expr.BuildContext) string {
 			if i > 0 {
 				sb.WriteString(", ")
 			}
-			sb.WriteString(selectColSQL(ctx, c))
+			sb.WriteString(distinctOnColSQL(ctx, c))
 		}
 		sb.WriteString(") ")
 	} else if b.distinct {
@@ -419,6 +422,21 @@ func (b *SelectBuilder) buildWith(ctx *expr.BuildContext) string {
 // ToSQL is called directly so the aggregate function syntax is preserved.
 // For plain columns the standard quoted "table"."col" form is returned.
 func selectColSQL(ctx *expr.BuildContext, c expr.SelectableColumn) string {
+	if e, ok := c.(expr.Expression); ok {
+		return e.ToSQL(ctx)
+	}
+	return ctx.ColRef(c.TableName(), c.ColumnName())
+}
+
+// distinctOnColSQL produces the SQL fragment for a column inside a DISTINCT ON (...)
+// clause. PostgreSQL does not permit AS aliases inside DISTINCT ON, so aliased
+// expressions must be rendered without their alias. Types that implement
+// expr.BareExpression provide a ToSQLBare method for exactly this purpose.
+// Plain columns are rendered using their standard quoted reference.
+func distinctOnColSQL(ctx *expr.BuildContext, c expr.SelectableColumn) string {
+	if be, ok := c.(expr.BareExpression); ok {
+		return be.ToSQLBare(ctx)
+	}
 	if e, ok := c.(expr.Expression); ok {
 		return e.ToSQL(ctx)
 	}


### PR DESCRIPTION
Closes #45

## Summary
- Add `DistinctOn(cols ...expr.SelectableColumn)` method to `SelectBuilder`
- Renders `SELECT DISTINCT ON ("col1", "col2") ...` correctly on PostgreSQL
- Calling `DistinctOn` overrides any previous `Distinct()` call
- No-op on MySQL and SQLite (unsupported dialects), with no error emitted
- Docs note that PostgreSQL requires `ORDER BY` to start with the same columns as `DISTINCT ON`

## Test plan
- [x] Single-column `DISTINCT ON`
- [x] Multi-column `DISTINCT ON`
- [x] Combined with `ORDER BY`, `LIMIT`, and `OFFSET`
- [x] `DistinctOn` overrides prior `Distinct()` call
- [x] No-op on MySQL dialect
- [x] No-op on SQLite dialect
- [x] Existing `DISTINCT` tests continue to pass
- [x] Full test suite passes