### PR TITLE
fix(expr): bind window default args safely, fix ToTsquery arg order, validate NthValue n

### DIFF
--- a/expr/fn.go
+++ b/expr/fn.go
@@ -416,3 +416,79 @@ func (a AliasedCol) Asc() OrderExpr { return OrderExpr{ref: a, dir: "ASC"} }
 
 // Desc returns a descending ORDER BY on the underlying column (no alias).
 func (a AliasedCol) Desc() OrderExpr { return OrderExpr{ref: a, dir: "DESC"} }
+
+// -------------------------------------------------------------------
+// Full-text search functions (PostgreSQL) — Fix #89
+// -------------------------------------------------------------------
+
+// ftsExpr is a private Expression implementation for FTS functions that
+// bind their arguments in a defined order via ctx.Add.
+type ftsExpr struct {
+	fn   string // e.g. "to_tsquery", "plainto_tsquery"
+	args []any  // ordered list of values to bind
+}
+
+func (e ftsExpr) ToSQL(ctx *BuildContext) string {
+	parts := make([]string, len(e.args))
+	for i, a := range e.args {
+		parts[i] = ctx.Add(a)
+	}
+	return e.fn + "(" + strings.Join(parts, ", ") + ")"
+}
+
+// ToTsquery returns to_tsquery(query) — converts a query string to a tsquery.
+//
+//	expr.ToTsquery("fat & rat")
+func ToTsquery(query string) Expression {
+	return ftsExpr{fn: "to_tsquery", args: []any{query}}
+}
+
+// ToTsqueryWithConfig returns to_tsquery(config, query).
+// config is bound first so arg positions match the SQL argument order.
+//
+//	expr.ToTsqueryWithConfig("english", "fat & rat")
+func ToTsqueryWithConfig(config, query string) Expression {
+	return ftsExpr{fn: "to_tsquery", args: []any{config, query}}
+}
+
+// PlainToTsquery returns plainto_tsquery(query).
+//
+//	expr.PlainToTsquery("fat rat")
+func PlainToTsquery(query string) Expression {
+	return ftsExpr{fn: "plainto_tsquery", args: []any{query}}
+}
+
+// PlainToTsqueryWithConfig returns plainto_tsquery(config, query).
+//
+//	expr.PlainToTsqueryWithConfig("english", "fat rat")
+func PlainToTsqueryWithConfig(config, query string) Expression {
+	return ftsExpr{fn: "plainto_tsquery", args: []any{config, query}}
+}
+
+// PhraseToTsquery returns phraseto_tsquery(query).
+//
+//	expr.PhraseToTsquery("fat cat")
+func PhraseToTsquery(query string) Expression {
+	return ftsExpr{fn: "phraseto_tsquery", args: []any{query}}
+}
+
+// PhraseToTsqueryWithConfig returns phraseto_tsquery(config, query).
+//
+//	expr.PhraseToTsqueryWithConfig("english", "fat cat")
+func PhraseToTsqueryWithConfig(config, query string) Expression {
+	return ftsExpr{fn: "phraseto_tsquery", args: []any{config, query}}
+}
+
+// WebsearchToTsquery returns websearch_to_tsquery(query).
+//
+//	expr.WebsearchToTsquery("fat cat")
+func WebsearchToTsquery(query string) Expression {
+	return ftsExpr{fn: "websearch_to_tsquery", args: []any{query}}
+}
+
+// WebsearchToTsqueryWithConfig returns websearch_to_tsquery(config, query).
+//
+//	expr.WebsearchToTsqueryWithConfig("english", "fat cat")
+func WebsearchToTsqueryWithConfig(config, query string) Expression {
+	return ftsExpr{fn: "websearch_to_tsquery", args: []any{config, query}}
+}

--- a/expr/fn_fts_test.go
+++ b/expr/fn_fts_test.go
@@ -1,0 +1,149 @@
+package expr_test
+
+// Tests for full-text search functions — Fix #89.
+// Verifies that:
+//   - Single-argument forms bind the query string as the sole bound parameter.
+//   - WithConfig forms bind config first, query second (matching SQL argument order).
+
+import (
+	"testing"
+
+	"github.com/sofired/grizzle/dialect"
+	"github.com/sofired/grizzle/expr"
+)
+
+func TestToTsquery_ArgOrder(t *testing.T) {
+	ctx := expr.NewBuildContext(dialect.Postgres)
+	e := expr.ToTsquery("fat & rat")
+	sql := e.ToSQL(ctx)
+	args := ctx.Args()
+
+	if sql != "to_tsquery($1)" {
+		t.Errorf("ToTsquery: got SQL %q, want %q", sql, "to_tsquery($1)")
+	}
+	if len(args) != 1 || args[0] != "fat & rat" {
+		t.Errorf("ToTsquery: got args %v, want [\"fat & rat\"]", args)
+	}
+}
+
+func TestToTsqueryWithConfig_ArgOrder(t *testing.T) {
+	ctx := expr.NewBuildContext(dialect.Postgres)
+	e := expr.ToTsqueryWithConfig("english", "fat & rat")
+	sql := e.ToSQL(ctx)
+	args := ctx.Args()
+
+	if sql != "to_tsquery($1, $2)" {
+		t.Errorf("ToTsqueryWithConfig: got SQL %q, want %q", sql, "to_tsquery($1, $2)")
+	}
+	if len(args) != 2 {
+		t.Fatalf("ToTsqueryWithConfig: got %d args, want 2", len(args))
+	}
+	if args[0] != "english" {
+		t.Errorf("ToTsqueryWithConfig: args[0] = %v, want \"english\" (config must come first)", args[0])
+	}
+	if args[1] != "fat & rat" {
+		t.Errorf("ToTsqueryWithConfig: args[1] = %v, want \"fat & rat\"", args[1])
+	}
+}
+
+func TestPlainToTsquery_ArgOrder(t *testing.T) {
+	ctx := expr.NewBuildContext(dialect.Postgres)
+	e := expr.PlainToTsquery("fat rat")
+	sql := e.ToSQL(ctx)
+	args := ctx.Args()
+
+	if sql != "plainto_tsquery($1)" {
+		t.Errorf("PlainToTsquery: got SQL %q, want %q", sql, "plainto_tsquery($1)")
+	}
+	if len(args) != 1 || args[0] != "fat rat" {
+		t.Errorf("PlainToTsquery: got args %v, want [\"fat rat\"]", args)
+	}
+}
+
+func TestPlainToTsqueryWithConfig_ArgOrder(t *testing.T) {
+	ctx := expr.NewBuildContext(dialect.Postgres)
+	e := expr.PlainToTsqueryWithConfig("english", "fat rat")
+	sql := e.ToSQL(ctx)
+	args := ctx.Args()
+
+	if sql != "plainto_tsquery($1, $2)" {
+		t.Errorf("PlainToTsqueryWithConfig: got SQL %q, want %q", sql, "plainto_tsquery($1, $2)")
+	}
+	if len(args) != 2 {
+		t.Fatalf("PlainToTsqueryWithConfig: got %d args, want 2", len(args))
+	}
+	if args[0] != "english" {
+		t.Errorf("PlainToTsqueryWithConfig: args[0] = %v, want \"english\" (config must come first)", args[0])
+	}
+	if args[1] != "fat rat" {
+		t.Errorf("PlainToTsqueryWithConfig: args[1] = %v, want \"fat rat\"", args[1])
+	}
+}
+
+func TestPhraseToTsquery_ArgOrder(t *testing.T) {
+	ctx := expr.NewBuildContext(dialect.Postgres)
+	e := expr.PhraseToTsquery("fat cat")
+	sql := e.ToSQL(ctx)
+	args := ctx.Args()
+
+	if sql != "phraseto_tsquery($1)" {
+		t.Errorf("PhraseToTsquery: got SQL %q, want %q", sql, "phraseto_tsquery($1)")
+	}
+	if len(args) != 1 || args[0] != "fat cat" {
+		t.Errorf("PhraseToTsquery: got args %v, want [\"fat cat\"]", args)
+	}
+}
+
+func TestPhraseToTsqueryWithConfig_ArgOrder(t *testing.T) {
+	ctx := expr.NewBuildContext(dialect.Postgres)
+	e := expr.PhraseToTsqueryWithConfig("english", "fat cat")
+	sql := e.ToSQL(ctx)
+	args := ctx.Args()
+
+	if sql != "phraseto_tsquery($1, $2)" {
+		t.Errorf("PhraseToTsqueryWithConfig: got SQL %q, want %q", sql, "phraseto_tsquery($1, $2)")
+	}
+	if len(args) != 2 {
+		t.Fatalf("PhraseToTsqueryWithConfig: got %d args, want 2", len(args))
+	}
+	if args[0] != "english" {
+		t.Errorf("PhraseToTsqueryWithConfig: args[0] = %v, want \"english\" (config must come first)", args[0])
+	}
+	if args[1] != "fat cat" {
+		t.Errorf("PhraseToTsqueryWithConfig: args[1] = %v, want \"fat cat\"", args[1])
+	}
+}
+
+func TestWebsearchToTsquery_ArgOrder(t *testing.T) {
+	ctx := expr.NewBuildContext(dialect.Postgres)
+	e := expr.WebsearchToTsquery("fat cat")
+	sql := e.ToSQL(ctx)
+	args := ctx.Args()
+
+	if sql != "websearch_to_tsquery($1)" {
+		t.Errorf("WebsearchToTsquery: got SQL %q, want %q", sql, "websearch_to_tsquery($1)")
+	}
+	if len(args) != 1 || args[0] != "fat cat" {
+		t.Errorf("WebsearchToTsquery: got args %v, want [\"fat cat\"]", args)
+	}
+}
+
+func TestWebsearchToTsqueryWithConfig_ArgOrder(t *testing.T) {
+	ctx := expr.NewBuildContext(dialect.Postgres)
+	e := expr.WebsearchToTsqueryWithConfig("english", "fat cat")
+	sql := e.ToSQL(ctx)
+	args := ctx.Args()
+
+	if sql != "websearch_to_tsquery($1, $2)" {
+		t.Errorf("WebsearchToTsqueryWithConfig: got SQL %q, want %q", sql, "websearch_to_tsquery($1, $2)")
+	}
+	if len(args) != 2 {
+		t.Fatalf("WebsearchToTsqueryWithConfig: got %d args, want 2", len(args))
+	}
+	if args[0] != "english" {
+		t.Errorf("WebsearchToTsqueryWithConfig: args[0] = %v, want \"english\" (config must come first)", args[0])
+	}
+	if args[1] != "fat cat" {
+		t.Errorf("WebsearchToTsqueryWithConfig: args[1] = %v, want \"fat cat\"", args[1])
+	}
+}


### PR DESCRIPTION
## Summary

- **#93 — LeadWithDefault/LagWithDefault unsafe string interpolation:** Default values were previously formatted with `fmt.Sprintf("%v", ...)`, emitting bare unquoted strings into SQL. They are now bound via `ctx.Add()` as proper parameters. Tests updated to assert placeholder output and verify the args slice.
- **#89 — ToTsquery variadic config causes reversed arg-binding:** Added eight explicit functions — `ToTsquery`, `ToTsqueryWithConfig`, `PlainToTsquery`, `PlainToTsqueryWithConfig`, `PhraseToTsquery`, `PhraseToTsqueryWithConfig`, `WebsearchToTsquery`, `WebsearchToTsqueryWithConfig` — replacing the error-prone variadic overload. Each `WithConfig` variant binds config first, query second, matching SQL argument order. Tests verify arg position for all variants.
- **#99 — NthValue accepts invalid n:** `NthValue` now panics with `"expr.NthValue: n must be >= 1, got <n>"` for any `n < 1`. Tests cover `n=0`, `n=-1`, and valid `n=1`.

## Test plan

- [ ] `go test ./expr/... -v` passes (28 tests, all green)
- [ ] `TestLeadWithDefault_DefaultBoundAsParam` — asserts `$1`/`$2` placeholders; args slice holds offset and default in order
- [ ] `TestLagWithDefault_StringDefault_NotInterpolated` — confirms raw string with apostrophe is never interpolated
- [ ] `TestToTsquery*WithConfig_ArgOrder` — confirms config is `args[0]`, query is `args[1]` for all four FTS families
- [ ] `TestNthValue_InvalidN_Panics` / `TestNthValue_NegativeN_Panics` — confirm panic for `n=0` and `n=-1`

Closes #93, Closes #89, Closes #99