### PR TITLE
fix(expr): bind LeadWithDefault/LagWithDefault default values as parameters

### DIFF
--- a/expr/fn.go
+++ b/expr/fn.go
@@ -416,74 +416,61 @@ func (a AliasedCol) Desc() OrderExpr { return OrderExpr{ref: a, dir: "DESC"} }
 // Full-text search functions (PostgreSQL) — Fix #89
 // -------------------------------------------------------------------
 
-// ftsExpr is a private Expression implementation for FTS functions that
-// bind their arguments in a defined order via ctx.Add.
-type ftsExpr struct {
-	fn   string // e.g. "to_tsquery", "plainto_tsquery"
-	args []any  // ordered list of values to bind
-}
-
-func (e ftsExpr) ToSQL(ctx *BuildContext) string {
-	parts := make([]string, len(e.args))
-	for i, a := range e.args {
-		parts[i] = ctx.Add(a)
-	}
-	return e.fn + "(" + strings.Join(parts, ", ") + ")"
-}
-
-// ToTsquery returns to_tsquery(query) — converts a query string to a tsquery.
+// ToTsquery returns TO_TSQUERY(query) — converts a query string to a tsquery.
+// The result is a FuncExpr and supports As()/Asc()/Desc() and comparison
+// helpers, making it usable in SELECT lists, ORDER BY, and WHERE clauses.
 //
 //	expr.ToTsquery("fat & rat")
-func ToTsquery(query string) Expression {
-	return ftsExpr{fn: "to_tsquery", args: []any{query}}
+func ToTsquery(query string) FuncExpr {
+	return FuncExpr{fn: "TO_TSQUERY", args: []Expression{Lit(query)}}
 }
 
-// ToTsqueryWithConfig returns to_tsquery(config, query).
-// config is bound first so arg positions match the SQL argument order.
+// ToTsqueryWithConfig returns TO_TSQUERY(config, query).
+// config is passed first so arg positions match the SQL argument order.
 //
 //	expr.ToTsqueryWithConfig("english", "fat & rat")
-func ToTsqueryWithConfig(config, query string) Expression {
-	return ftsExpr{fn: "to_tsquery", args: []any{config, query}}
+func ToTsqueryWithConfig(config, query string) FuncExpr {
+	return FuncExpr{fn: "TO_TSQUERY", args: []Expression{Lit(config), Lit(query)}}
 }
 
-// PlainToTsquery returns plainto_tsquery(query).
+// PlainToTsquery returns PLAINTO_TSQUERY(query).
 //
 //	expr.PlainToTsquery("fat rat")
-func PlainToTsquery(query string) Expression {
-	return ftsExpr{fn: "plainto_tsquery", args: []any{query}}
+func PlainToTsquery(query string) FuncExpr {
+	return FuncExpr{fn: "PLAINTO_TSQUERY", args: []Expression{Lit(query)}}
 }
 
-// PlainToTsqueryWithConfig returns plainto_tsquery(config, query).
+// PlainToTsqueryWithConfig returns PLAINTO_TSQUERY(config, query).
 //
 //	expr.PlainToTsqueryWithConfig("english", "fat rat")
-func PlainToTsqueryWithConfig(config, query string) Expression {
-	return ftsExpr{fn: "plainto_tsquery", args: []any{config, query}}
+func PlainToTsqueryWithConfig(config, query string) FuncExpr {
+	return FuncExpr{fn: "PLAINTO_TSQUERY", args: []Expression{Lit(config), Lit(query)}}
 }
 
-// PhraseToTsquery returns phraseto_tsquery(query).
+// PhraseToTsquery returns PHRASETO_TSQUERY(query).
 //
 //	expr.PhraseToTsquery("fat cat")
-func PhraseToTsquery(query string) Expression {
-	return ftsExpr{fn: "phraseto_tsquery", args: []any{query}}
+func PhraseToTsquery(query string) FuncExpr {
+	return FuncExpr{fn: "PHRASETO_TSQUERY", args: []Expression{Lit(query)}}
 }
 
-// PhraseToTsqueryWithConfig returns phraseto_tsquery(config, query).
+// PhraseToTsqueryWithConfig returns PHRASETO_TSQUERY(config, query).
 //
 //	expr.PhraseToTsqueryWithConfig("english", "fat cat")
-func PhraseToTsqueryWithConfig(config, query string) Expression {
-	return ftsExpr{fn: "phraseto_tsquery", args: []any{config, query}}
+func PhraseToTsqueryWithConfig(config, query string) FuncExpr {
+	return FuncExpr{fn: "PHRASETO_TSQUERY", args: []Expression{Lit(config), Lit(query)}}
 }
 
-// WebsearchToTsquery returns websearch_to_tsquery(query).
+// WebsearchToTsquery returns WEBSEARCH_TO_TSQUERY(query).
 //
 //	expr.WebsearchToTsquery("fat cat")
-func WebsearchToTsquery(query string) Expression {
-	return ftsExpr{fn: "websearch_to_tsquery", args: []any{query}}
+func WebsearchToTsquery(query string) FuncExpr {
+	return FuncExpr{fn: "WEBSEARCH_TO_TSQUERY", args: []Expression{Lit(query)}}
 }
 
-// WebsearchToTsqueryWithConfig returns websearch_to_tsquery(config, query).
+// WebsearchToTsqueryWithConfig returns WEBSEARCH_TO_TSQUERY(config, query).
 //
 //	expr.WebsearchToTsqueryWithConfig("english", "fat cat")
-func WebsearchToTsqueryWithConfig(config, query string) Expression {
-	return ftsExpr{fn: "websearch_to_tsquery", args: []any{config, query}}
+func WebsearchToTsqueryWithConfig(config, query string) FuncExpr {
+	return FuncExpr{fn: "WEBSEARCH_TO_TSQUERY", args: []Expression{Lit(config), Lit(query)}}
 }

--- a/expr/fn.go
+++ b/expr/fn.go
@@ -411,3 +411,79 @@ func (a AliasedCol) Asc() OrderExpr { return OrderExpr{ref: a, dir: "ASC"} }
 
 // Desc returns a descending ORDER BY on the underlying column (no alias).
 func (a AliasedCol) Desc() OrderExpr { return OrderExpr{ref: a, dir: "DESC"} }
+
+// -------------------------------------------------------------------
+// Full-text search functions (PostgreSQL) — Fix #89
+// -------------------------------------------------------------------
+
+// ftsExpr is a private Expression implementation for FTS functions that
+// bind their arguments in a defined order via ctx.Add.
+type ftsExpr struct {
+	fn   string // e.g. "to_tsquery", "plainto_tsquery"
+	args []any  // ordered list of values to bind
+}
+
+func (e ftsExpr) ToSQL(ctx *BuildContext) string {
+	parts := make([]string, len(e.args))
+	for i, a := range e.args {
+		parts[i] = ctx.Add(a)
+	}
+	return e.fn + "(" + strings.Join(parts, ", ") + ")"
+}
+
+// ToTsquery returns to_tsquery(query) — converts a query string to a tsquery.
+//
+//	expr.ToTsquery("fat & rat")
+func ToTsquery(query string) Expression {
+	return ftsExpr{fn: "to_tsquery", args: []any{query}}
+}
+
+// ToTsqueryWithConfig returns to_tsquery(config, query).
+// config is bound first so arg positions match the SQL argument order.
+//
+//	expr.ToTsqueryWithConfig("english", "fat & rat")
+func ToTsqueryWithConfig(config, query string) Expression {
+	return ftsExpr{fn: "to_tsquery", args: []any{config, query}}
+}
+
+// PlainToTsquery returns plainto_tsquery(query).
+//
+//	expr.PlainToTsquery("fat rat")
+func PlainToTsquery(query string) Expression {
+	return ftsExpr{fn: "plainto_tsquery", args: []any{query}}
+}
+
+// PlainToTsqueryWithConfig returns plainto_tsquery(config, query).
+//
+//	expr.PlainToTsqueryWithConfig("english", "fat rat")
+func PlainToTsqueryWithConfig(config, query string) Expression {
+	return ftsExpr{fn: "plainto_tsquery", args: []any{config, query}}
+}
+
+// PhraseToTsquery returns phraseto_tsquery(query).
+//
+//	expr.PhraseToTsquery("fat cat")
+func PhraseToTsquery(query string) Expression {
+	return ftsExpr{fn: "phraseto_tsquery", args: []any{query}}
+}
+
+// PhraseToTsqueryWithConfig returns phraseto_tsquery(config, query).
+//
+//	expr.PhraseToTsqueryWithConfig("english", "fat cat")
+func PhraseToTsqueryWithConfig(config, query string) Expression {
+	return ftsExpr{fn: "phraseto_tsquery", args: []any{config, query}}
+}
+
+// WebsearchToTsquery returns websearch_to_tsquery(query).
+//
+//	expr.WebsearchToTsquery("fat cat")
+func WebsearchToTsquery(query string) Expression {
+	return ftsExpr{fn: "websearch_to_tsquery", args: []any{query}}
+}
+
+// WebsearchToTsqueryWithConfig returns websearch_to_tsquery(config, query).
+//
+//	expr.WebsearchToTsqueryWithConfig("english", "fat cat")
+func WebsearchToTsqueryWithConfig(config, query string) Expression {
+	return ftsExpr{fn: "websearch_to_tsquery", args: []any{config, query}}
+}

--- a/expr/fn_fts_test.go
+++ b/expr/fn_fts_test.go
@@ -18,8 +18,8 @@ func TestToTsquery_ArgOrder(t *testing.T) {
 	sql := e.ToSQL(ctx)
 	args := ctx.Args()
 
-	if sql != "to_tsquery($1)" {
-		t.Errorf("ToTsquery: got SQL %q, want %q", sql, "to_tsquery($1)")
+	if sql != "TO_TSQUERY($1)" {
+		t.Errorf("ToTsquery: got SQL %q, want %q", sql, "TO_TSQUERY($1)")
 	}
 	if len(args) != 1 || args[0] != "fat & rat" {
 		t.Errorf("ToTsquery: got args %v, want [\"fat & rat\"]", args)
@@ -32,8 +32,8 @@ func TestToTsqueryWithConfig_ArgOrder(t *testing.T) {
 	sql := e.ToSQL(ctx)
 	args := ctx.Args()
 
-	if sql != "to_tsquery($1, $2)" {
-		t.Errorf("ToTsqueryWithConfig: got SQL %q, want %q", sql, "to_tsquery($1, $2)")
+	if sql != "TO_TSQUERY($1, $2)" {
+		t.Errorf("ToTsqueryWithConfig: got SQL %q, want %q", sql, "TO_TSQUERY($1, $2)")
 	}
 	if len(args) != 2 {
 		t.Fatalf("ToTsqueryWithConfig: got %d args, want 2", len(args))
@@ -52,8 +52,8 @@ func TestPlainToTsquery_ArgOrder(t *testing.T) {
 	sql := e.ToSQL(ctx)
 	args := ctx.Args()
 
-	if sql != "plainto_tsquery($1)" {
-		t.Errorf("PlainToTsquery: got SQL %q, want %q", sql, "plainto_tsquery($1)")
+	if sql != "PLAINTO_TSQUERY($1)" {
+		t.Errorf("PlainToTsquery: got SQL %q, want %q", sql, "PLAINTO_TSQUERY($1)")
 	}
 	if len(args) != 1 || args[0] != "fat rat" {
 		t.Errorf("PlainToTsquery: got args %v, want [\"fat rat\"]", args)
@@ -66,8 +66,8 @@ func TestPlainToTsqueryWithConfig_ArgOrder(t *testing.T) {
 	sql := e.ToSQL(ctx)
 	args := ctx.Args()
 
-	if sql != "plainto_tsquery($1, $2)" {
-		t.Errorf("PlainToTsqueryWithConfig: got SQL %q, want %q", sql, "plainto_tsquery($1, $2)")
+	if sql != "PLAINTO_TSQUERY($1, $2)" {
+		t.Errorf("PlainToTsqueryWithConfig: got SQL %q, want %q", sql, "PLAINTO_TSQUERY($1, $2)")
 	}
 	if len(args) != 2 {
 		t.Fatalf("PlainToTsqueryWithConfig: got %d args, want 2", len(args))
@@ -86,8 +86,8 @@ func TestPhraseToTsquery_ArgOrder(t *testing.T) {
 	sql := e.ToSQL(ctx)
 	args := ctx.Args()
 
-	if sql != "phraseto_tsquery($1)" {
-		t.Errorf("PhraseToTsquery: got SQL %q, want %q", sql, "phraseto_tsquery($1)")
+	if sql != "PHRASETO_TSQUERY($1)" {
+		t.Errorf("PhraseToTsquery: got SQL %q, want %q", sql, "PHRASETO_TSQUERY($1)")
 	}
 	if len(args) != 1 || args[0] != "fat cat" {
 		t.Errorf("PhraseToTsquery: got args %v, want [\"fat cat\"]", args)
@@ -100,8 +100,8 @@ func TestPhraseToTsqueryWithConfig_ArgOrder(t *testing.T) {
 	sql := e.ToSQL(ctx)
 	args := ctx.Args()
 
-	if sql != "phraseto_tsquery($1, $2)" {
-		t.Errorf("PhraseToTsqueryWithConfig: got SQL %q, want %q", sql, "phraseto_tsquery($1, $2)")
+	if sql != "PHRASETO_TSQUERY($1, $2)" {
+		t.Errorf("PhraseToTsqueryWithConfig: got SQL %q, want %q", sql, "PHRASETO_TSQUERY($1, $2)")
 	}
 	if len(args) != 2 {
 		t.Fatalf("PhraseToTsqueryWithConfig: got %d args, want 2", len(args))
@@ -120,8 +120,8 @@ func TestWebsearchToTsquery_ArgOrder(t *testing.T) {
 	sql := e.ToSQL(ctx)
 	args := ctx.Args()
 
-	if sql != "websearch_to_tsquery($1)" {
-		t.Errorf("WebsearchToTsquery: got SQL %q, want %q", sql, "websearch_to_tsquery($1)")
+	if sql != "WEBSEARCH_TO_TSQUERY($1)" {
+		t.Errorf("WebsearchToTsquery: got SQL %q, want %q", sql, "WEBSEARCH_TO_TSQUERY($1)")
 	}
 	if len(args) != 1 || args[0] != "fat cat" {
 		t.Errorf("WebsearchToTsquery: got args %v, want [\"fat cat\"]", args)
@@ -134,8 +134,8 @@ func TestWebsearchToTsqueryWithConfig_ArgOrder(t *testing.T) {
 	sql := e.ToSQL(ctx)
 	args := ctx.Args()
 
-	if sql != "websearch_to_tsquery($1, $2)" {
-		t.Errorf("WebsearchToTsqueryWithConfig: got SQL %q, want %q", sql, "websearch_to_tsquery($1, $2)")
+	if sql != "WEBSEARCH_TO_TSQUERY($1, $2)" {
+		t.Errorf("WebsearchToTsqueryWithConfig: got SQL %q, want %q", sql, "WEBSEARCH_TO_TSQUERY($1, $2)")
 	}
 	if len(args) != 2 {
 		t.Fatalf("WebsearchToTsqueryWithConfig: got %d args, want 2", len(args))

--- a/expr/fn_fts_test.go
+++ b/expr/fn_fts_test.go
@@ -1,0 +1,149 @@
+package expr_test
+
+// Tests for full-text search functions — Fix #89.
+// Verifies that:
+//   - Single-argument forms bind the query string as the sole bound parameter.
+//   - WithConfig forms bind config first, query second (matching SQL argument order).
+
+import (
+	"testing"
+
+	"github.com/sofired/grizzle/dialect"
+	"github.com/sofired/grizzle/expr"
+)
+
+func TestToTsquery_ArgOrder(t *testing.T) {
+	ctx := expr.NewBuildContext(dialect.Postgres)
+	e := expr.ToTsquery("fat & rat")
+	sql := e.ToSQL(ctx)
+	args := ctx.Args()
+
+	if sql != "to_tsquery($1)" {
+		t.Errorf("ToTsquery: got SQL %q, want %q", sql, "to_tsquery($1)")
+	}
+	if len(args) != 1 || args[0] != "fat & rat" {
+		t.Errorf("ToTsquery: got args %v, want [\"fat & rat\"]", args)
+	}
+}
+
+func TestToTsqueryWithConfig_ArgOrder(t *testing.T) {
+	ctx := expr.NewBuildContext(dialect.Postgres)
+	e := expr.ToTsqueryWithConfig("english", "fat & rat")
+	sql := e.ToSQL(ctx)
+	args := ctx.Args()
+
+	if sql != "to_tsquery($1, $2)" {
+		t.Errorf("ToTsqueryWithConfig: got SQL %q, want %q", sql, "to_tsquery($1, $2)")
+	}
+	if len(args) != 2 {
+		t.Fatalf("ToTsqueryWithConfig: got %d args, want 2", len(args))
+	}
+	if args[0] != "english" {
+		t.Errorf("ToTsqueryWithConfig: args[0] = %v, want \"english\" (config must come first)", args[0])
+	}
+	if args[1] != "fat & rat" {
+		t.Errorf("ToTsqueryWithConfig: args[1] = %v, want \"fat & rat\"", args[1])
+	}
+}
+
+func TestPlainToTsquery_ArgOrder(t *testing.T) {
+	ctx := expr.NewBuildContext(dialect.Postgres)
+	e := expr.PlainToTsquery("fat rat")
+	sql := e.ToSQL(ctx)
+	args := ctx.Args()
+
+	if sql != "plainto_tsquery($1)" {
+		t.Errorf("PlainToTsquery: got SQL %q, want %q", sql, "plainto_tsquery($1)")
+	}
+	if len(args) != 1 || args[0] != "fat rat" {
+		t.Errorf("PlainToTsquery: got args %v, want [\"fat rat\"]", args)
+	}
+}
+
+func TestPlainToTsqueryWithConfig_ArgOrder(t *testing.T) {
+	ctx := expr.NewBuildContext(dialect.Postgres)
+	e := expr.PlainToTsqueryWithConfig("english", "fat rat")
+	sql := e.ToSQL(ctx)
+	args := ctx.Args()
+
+	if sql != "plainto_tsquery($1, $2)" {
+		t.Errorf("PlainToTsqueryWithConfig: got SQL %q, want %q", sql, "plainto_tsquery($1, $2)")
+	}
+	if len(args) != 2 {
+		t.Fatalf("PlainToTsqueryWithConfig: got %d args, want 2", len(args))
+	}
+	if args[0] != "english" {
+		t.Errorf("PlainToTsqueryWithConfig: args[0] = %v, want \"english\" (config must come first)", args[0])
+	}
+	if args[1] != "fat rat" {
+		t.Errorf("PlainToTsqueryWithConfig: args[1] = %v, want \"fat rat\"", args[1])
+	}
+}
+
+func TestPhraseToTsquery_ArgOrder(t *testing.T) {
+	ctx := expr.NewBuildContext(dialect.Postgres)
+	e := expr.PhraseToTsquery("fat cat")
+	sql := e.ToSQL(ctx)
+	args := ctx.Args()
+
+	if sql != "phraseto_tsquery($1)" {
+		t.Errorf("PhraseToTsquery: got SQL %q, want %q", sql, "phraseto_tsquery($1)")
+	}
+	if len(args) != 1 || args[0] != "fat cat" {
+		t.Errorf("PhraseToTsquery: got args %v, want [\"fat cat\"]", args)
+	}
+}
+
+func TestPhraseToTsqueryWithConfig_ArgOrder(t *testing.T) {
+	ctx := expr.NewBuildContext(dialect.Postgres)
+	e := expr.PhraseToTsqueryWithConfig("english", "fat cat")
+	sql := e.ToSQL(ctx)
+	args := ctx.Args()
+
+	if sql != "phraseto_tsquery($1, $2)" {
+		t.Errorf("PhraseToTsqueryWithConfig: got SQL %q, want %q", sql, "phraseto_tsquery($1, $2)")
+	}
+	if len(args) != 2 {
+		t.Fatalf("PhraseToTsqueryWithConfig: got %d args, want 2", len(args))
+	}
+	if args[0] != "english" {
+		t.Errorf("PhraseToTsqueryWithConfig: args[0] = %v, want \"english\" (config must come first)", args[0])
+	}
+	if args[1] != "fat cat" {
+		t.Errorf("PhraseToTsqueryWithConfig: args[1] = %v, want \"fat cat\"", args[1])
+	}
+}
+
+func TestWebsearchToTsquery_ArgOrder(t *testing.T) {
+	ctx := expr.NewBuildContext(dialect.Postgres)
+	e := expr.WebsearchToTsquery("fat cat")
+	sql := e.ToSQL(ctx)
+	args := ctx.Args()
+
+	if sql != "websearch_to_tsquery($1)" {
+		t.Errorf("WebsearchToTsquery: got SQL %q, want %q", sql, "websearch_to_tsquery($1)")
+	}
+	if len(args) != 1 || args[0] != "fat cat" {
+		t.Errorf("WebsearchToTsquery: got args %v, want [\"fat cat\"]", args)
+	}
+}
+
+func TestWebsearchToTsqueryWithConfig_ArgOrder(t *testing.T) {
+	ctx := expr.NewBuildContext(dialect.Postgres)
+	e := expr.WebsearchToTsqueryWithConfig("english", "fat cat")
+	sql := e.ToSQL(ctx)
+	args := ctx.Args()
+
+	if sql != "websearch_to_tsquery($1, $2)" {
+		t.Errorf("WebsearchToTsqueryWithConfig: got SQL %q, want %q", sql, "websearch_to_tsquery($1, $2)")
+	}
+	if len(args) != 2 {
+		t.Fatalf("WebsearchToTsqueryWithConfig: got %d args, want 2", len(args))
+	}
+	if args[0] != "english" {
+		t.Errorf("WebsearchToTsqueryWithConfig: args[0] = %v, want \"english\" (config must come first)", args[0])
+	}
+	if args[1] != "fat cat" {
+		t.Errorf("WebsearchToTsqueryWithConfig: args[1] = %v, want \"fat cat\"", args[1])
+	}
+}


### PR DESCRIPTION
## Summary

- **#93 — LeadWithDefault/LagWithDefault unsafe string interpolation:** Default values were previously formatted with `fmt.Sprintf("%v", ...)`, emitting bare unquoted strings into SQL (e.g. `unknown` instead of `'unknown'` or a bound parameter). They are now bound via `ctx.Add()` as proper parameters, preventing SQL injection and invalid SQL.
- **#89 — ToTsquery variadic config causes reversed arg-binding:** Added eight explicit functions — `ToTsquery`, `ToTsqueryWithConfig`, `PlainToTsquery`, `PlainToTsqueryWithConfig`, `PhraseToTsquery`, `PhraseToTsqueryWithConfig`, `WebsearchToTsquery`, `WebsearchToTsqueryWithConfig` — replacing any error-prone variadic overload. Each `WithConfig` variant binds config first, query second, matching SQL argument order. Tests verify arg position for all variants.
- **#99 — NthValue accepts invalid n:** `NthValue` now panics with `"expr.NthValue: n must be >= 1, got <n>"` for any `n < 1`. Tests cover `n=0`, `n=-1`, and valid `n=1`.

### Before (broken)

```sql
LEAD("users"."username", 1, unknown) OVER (ORDER BY "users"."score" ASC)
```

### After (correct)

```sql
LEAD("users"."username", $1, $2) OVER (ORDER BY "users"."score" ASC)
-- args: [1, "N/A"]
```

## Test plan

- [x] `go test ./expr/... -v` passes (all tests green)
- [x] `TestLeadWithDefault_DefaultBoundAsParam` — asserts `$1`/`$2` placeholders; args slice holds offset and default in order
- [x] `TestLagWithDefault_DefaultBoundAsParam` — verifies numeric default (0) is bound as a param
- [x] `TestLagWithDefault_StringDefault_NotInterpolated` — confirms raw string with apostrophe is never interpolated
- [x] `TestToTsquery*WithConfig_ArgOrder` — confirms config is `args[0]`, query is `args[1]` for all four FTS families
- [x] `TestNthValue_InvalidN_Panics` / `TestNthValue_NegativeN_Panics` — confirm panic for `n=0` and `n=-1`
- [x] `go test ./...` passes (all packages green)

Closes #93