### PR TITLE
fix(expr): AliasedCol.ToSQL no longer emits AS clause in GROUP BY and SubqueryIn contexts

### DIFF
--- a/expr/columns.go
+++ b/expr/columns.go
@@ -112,6 +112,15 @@ type SelectableColumn interface {
 	TableName() string
 }
 
+// ColRef returns the bare column reference (e.g. "table"."col") for col,
+// without any SELECT-list alias. Use this in GROUP BY, DISTINCT ON,
+// SubqueryIn, and other non-SELECT positions where an AS clause is invalid.
+// For plain columns this is identical to the SELECT-list form; for AliasedCol
+// it omits the AS clause that ToSQL would include.
+func ColRef(col SelectableColumn, ctx *BuildContext) string {
+	return col.colRef(ctx)
+}
+
 // -------------------------------------------------------------------
 // UUIDColumn
 // -------------------------------------------------------------------

--- a/query/query_test.go
+++ b/query/query_test.go
@@ -2216,3 +2216,53 @@ func TestWithRecursive_AndRegularCTE(t *testing.T) {
 		t.Errorf("expected WITH RECURSIVE (any recursive CTE triggers it), got: %s", sql)
 	}
 }
+
+// -------------------------------------------------------------------
+// Fix #131 — AliasedCol must not emit AS clause in non-SELECT contexts
+// -------------------------------------------------------------------
+
+func TestAliasedCol_GroupBy_NoASClause(t *testing.T) {
+	// GROUP BY must use the plain column reference, not "col AS alias".
+	aliased := expr.ColAs(ts.UsersT.RealmID, "rid")
+	assertSQL(t, "GROUP BY aliased col emits no AS clause",
+		query.Select(aliased, expr.Count().As("cnt")).
+			From(ts.UsersT).
+			GroupBy(aliased),
+		`SELECT "users"."realm_id" AS "rid", COUNT(*) AS "cnt" FROM "users" GROUP BY "users"."realm_id"`,
+		nil,
+	)
+}
+
+func TestAliasedCol_SubqueryIn_NoASClause(t *testing.T) {
+	// SubqueryIn must use the plain column reference, not "col AS alias".
+	aliased := expr.ColAs(ts.UsersT.RealmID, "rid")
+	sub := query.Select(ts.RealmsT.ID).From(ts.RealmsT).Where(ts.RealmsT.Name.EQ("acme"))
+	assertSQL(t, "SubqueryIn with aliased col emits no AS clause",
+		query.Select(ts.UsersT.ID).From(ts.UsersT).
+			Where(query.SubqueryIn(aliased, sub)),
+		`SELECT "users"."id" FROM "users" WHERE "users"."realm_id" IN (SELECT "realms"."id" FROM "realms" WHERE "realms"."name" = $1)`,
+		[]any{"acme"},
+	)
+}
+
+func TestAliasedCol_SubqueryNotIn_NoASClause(t *testing.T) {
+	// SubqueryNotIn must use the plain column reference, not "col AS alias".
+	aliased := expr.ColAs(ts.UsersT.RealmID, "rid")
+	sub := query.Select(ts.RealmsT.ID).From(ts.RealmsT).Where(ts.RealmsT.Name.EQ("banned"))
+	assertSQL(t, "SubqueryNotIn with aliased col emits no AS clause",
+		query.Select(ts.UsersT.ID).From(ts.UsersT).
+			Where(query.SubqueryNotIn(aliased, sub)),
+		`SELECT "users"."id" FROM "users" WHERE "users"."realm_id" NOT IN (SELECT "realms"."id" FROM "realms" WHERE "realms"."name" = $1)`,
+		[]any{"banned"},
+	)
+}
+
+func TestAliasedCol_SelectList_EmitsASClause(t *testing.T) {
+	// SELECT list must still include the AS alias — regression guard.
+	aliased := expr.ColAs(ts.UsersT.Email, "user_email")
+	assertSQL(t, "SELECT list with aliased col emits AS clause",
+		query.Select(ts.UsersT.ID, aliased).From(ts.UsersT),
+		`SELECT "users"."id", "users"."email" AS "user_email" FROM "users"`,
+		nil,
+	)
+}

--- a/query/select.go
+++ b/query/select.go
@@ -374,7 +374,7 @@ func (b *SelectBuilder) buildWith(ctx *expr.BuildContext) string {
 			if i > 0 {
 				sb.WriteString(", ")
 			}
-			sb.WriteString(selectColSQL(ctx, c))
+			sb.WriteString(expr.ColRef(c, ctx))
 		}
 	}
 
@@ -417,10 +417,14 @@ func (b *SelectBuilder) buildWith(ctx *expr.BuildContext) string {
 	return sb.String()
 }
 
-// selectColSQL produces the SQL fragment for a selectable column.
-// For aggregate expressions (COUNT, SUM, …) that implement expr.Expression,
-// ToSQL is called directly so the aggregate function syntax is preserved.
+// selectColSQL produces the SQL fragment for a column in a SELECT list.
+// For expressions that implement expr.Expression (aggregates, aliased columns,
+// arithmetic, window functions, …) ToSQL is called so that SELECT-list syntax
+// such as "AS alias" or "COUNT(*)" is preserved.
 // For plain columns the standard quoted "table"."col" form is returned.
+//
+// Use expr.ColRef for GROUP BY, DISTINCT ON, and SubqueryIn contexts where
+// an AS alias clause must not appear.
 func selectColSQL(ctx *expr.BuildContext, c expr.SelectableColumn) string {
 	if e, ok := c.(expr.Expression); ok {
 		return e.ToSQL(ctx)

--- a/query/subquery.go
+++ b/query/subquery.go
@@ -82,7 +82,7 @@ type subqueryInExpr struct {
 }
 
 func (e subqueryInExpr) ToSQL(ctx *expr.BuildContext) string {
-	return selectColSQL(ctx, e.col) + " IN (" + e.sub.buildWith(ctx) + ")"
+	return expr.ColRef(e.col, ctx) + " IN (" + e.sub.buildWith(ctx) + ")"
 }
 
 type subqueryNotInExpr struct {
@@ -91,5 +91,5 @@ type subqueryNotInExpr struct {
 }
 
 func (e subqueryNotInExpr) ToSQL(ctx *expr.BuildContext) string {
-	return selectColSQL(ctx, e.col) + " NOT IN (" + e.sub.buildWith(ctx) + ")"
+	return expr.ColRef(e.col, ctx) + " NOT IN (" + e.sub.buildWith(ctx) + ")"
 }


### PR DESCRIPTION
## Summary

- Fixes #131: `AliasedCol.ToSQL` was emitting `AS alias` in GROUP BY and SubqueryIn contexts, producing invalid SQL
- Introduces `expr.ColRef(col, ctx)` — an exported helper that delegates to the existing unexported `colRef` method, giving the `query` package access to the bare column reference without an alias
- Switches GROUP BY and SubqueryIn/SubqueryNotIn rendering to use `expr.ColRef` instead of `selectColSQL` (which calls `ToSQL`)
- `selectColSQL` and RETURNING contexts are unchanged — they continue to call `ToSQL` so aggregate/aliased/arithmetic expressions render correctly in SELECT lists

## Changes

- `expr/columns.go`: Added `func ColRef(col SelectableColumn, ctx *BuildContext) string`
- `query/select.go`: GROUP BY now uses `expr.ColRef`; updated `selectColSQL` comment
- `query/subquery.go`: SubqueryIn and SubqueryNotIn now use `expr.ColRef`
- `query/query_test.go`: Four new tests covering GROUP BY with aliased col, SubqueryIn, SubqueryNotIn, and SELECT list regression guard

## Test plan

- [ ] `TestAliasedCol_GroupBy_NoASClause` — GROUP BY renders `"users"."realm_id"`, not `"users"."realm_id" AS "rid"`
- [ ] `TestAliasedCol_SubqueryIn_NoASClause` — SubqueryIn renders bare column ref
- [ ] `TestAliasedCol_SubqueryNotIn_NoASClause` — SubqueryNotIn renders bare column ref
- [ ] `TestAliasedCol_SelectList_EmitsASClause` — regression: SELECT list still includes `AS "user_email"`
- [ ] All existing tests pass (`go test ./...`)

Closes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)