### PR TITLE
fix(kit): emit ON UPDATE in addConstraintSQL for FK constraints

### DIFF
--- a/kit/kit_test.go
+++ b/kit/kit_test.go
@@ -289,7 +289,7 @@ func TestGenerateChangeSQL_AddFKWithOnUpdate(t *testing.T) {
 	}
 	change := kit.Change{
 		Kind:       kit.ChangeAddConstraint,
-		TableName:  "users",
+		ObjectName: "users",
 		Constraint: &constraint,
 	}
 	stmts := kit.GenerateChangeSQL(snap, change)
@@ -322,7 +322,7 @@ func TestGenerateChangeSQL_AddFKWithOnUpdateOnly(t *testing.T) {
 	}
 	change := kit.Change{
 		Kind:       kit.ChangeAddConstraint,
-		TableName:  "users",
+		ObjectName: "users",
 		Constraint: &constraint,
 	}
 	stmts := kit.GenerateChangeSQL(snap, change)
@@ -354,7 +354,7 @@ func TestGenerateChangeSQL_AddFKDefaultActions(t *testing.T) {
 	}
 	change := kit.Change{
 		Kind:       kit.ChangeAddConstraint,
-		TableName:  "users",
+		ObjectName: "users",
 		Constraint: &constraint,
 	}
 	stmts := kit.GenerateChangeSQL(snap, change)
@@ -531,7 +531,7 @@ func TestMySQLChangeSQL_AddFKWithOnUpdate(t *testing.T) {
 	}
 	change := kit.Change{
 		Kind:       kit.ChangeAddConstraint,
-		TableName:  "users",
+		ObjectName: "users",
 		Constraint: &constraint,
 	}
 	stmts := kit.GenerateChangeSQLMySQL(snap, change)

--- a/kit/kit_test.go
+++ b/kit/kit_test.go
@@ -273,6 +273,103 @@ func TestGenerateChangeSQL_DropColumn(t *testing.T) {
 	}
 }
 
+// TestGenerateChangeSQL_AddFKWithOnUpdate verifies that addConstraintSQL emits
+// ON UPDATE <action> for FK constraints added via migration, matching the
+// createTableSQL path. Regression for issue #229.
+func TestGenerateChangeSQL_AddFKWithOnUpdate(t *testing.T) {
+	snap := kit.FromDefs(usersDef)
+	constraint := pg.Constraint{
+		Kind:       pg.KindForeignKey,
+		Name:       "users_realm_fk",
+		Columns:    []string{"realm_id"},
+		FKTable:    "realms",
+		FKColumns:  []string{"id"},
+		FKOnDelete: pg.FKActionCascade,
+		FKOnUpdate: pg.FKActionCascade,
+	}
+	change := kit.Change{
+		Kind:       kit.ChangeAddConstraint,
+		TableName:  "users",
+		Constraint: &constraint,
+	}
+	stmts := kit.GenerateChangeSQL(snap, change)
+	if len(stmts) != 1 {
+		t.Fatalf("expected 1 statement, got %d: %v", len(stmts), stmts)
+	}
+	got := stmts[0]
+	wantOnDelete := "ON DELETE CASCADE"
+	wantOnUpdate := "ON UPDATE CASCADE"
+	if !strings.Contains(got, wantOnDelete) {
+		t.Errorf("missing %q in:\n  %s", wantOnDelete, got)
+	}
+	if !strings.Contains(got, wantOnUpdate) {
+		t.Errorf("missing %q in:\n  %s", wantOnUpdate, got)
+	}
+}
+
+// TestGenerateChangeSQL_AddFKWithOnUpdateOnly verifies that a FK with only
+// ON UPDATE set (no ON DELETE) emits ON UPDATE but not ON DELETE.
+func TestGenerateChangeSQL_AddFKWithOnUpdateOnly(t *testing.T) {
+	snap := kit.FromDefs(usersDef)
+	constraint := pg.Constraint{
+		Kind:      pg.KindForeignKey,
+		Name:      "users_realm_fk",
+		Columns:   []string{"realm_id"},
+		FKTable:   "realms",
+		FKColumns: []string{"id"},
+		// FKOnDelete intentionally left as zero value (no action, not emitted).
+		FKOnUpdate: pg.FKActionRestrict,
+	}
+	change := kit.Change{
+		Kind:       kit.ChangeAddConstraint,
+		TableName:  "users",
+		Constraint: &constraint,
+	}
+	stmts := kit.GenerateChangeSQL(snap, change)
+	if len(stmts) != 1 {
+		t.Fatalf("expected 1 statement, got %d: %v", len(stmts), stmts)
+	}
+	got := stmts[0]
+	if strings.Contains(got, "ON DELETE") {
+		t.Errorf("unexpected ON DELETE clause when FKOnDelete is default:\n  %s", got)
+	}
+	wantOnUpdate := "ON UPDATE RESTRICT"
+	if !strings.Contains(got, wantOnUpdate) {
+		t.Errorf("missing %q in:\n  %s", wantOnUpdate, got)
+	}
+}
+
+// TestGenerateChangeSQL_AddFKDefaultActions verifies that ON UPDATE NO ACTION
+// (the default) is not emitted to keep SQL clean — matching ON DELETE behaviour.
+func TestGenerateChangeSQL_AddFKDefaultActions(t *testing.T) {
+	snap := kit.FromDefs(usersDef)
+	constraint := pg.Constraint{
+		Kind:       pg.KindForeignKey,
+		Name:       "users_realm_fk",
+		Columns:    []string{"realm_id"},
+		FKTable:    "realms",
+		FKColumns:  []string{"id"},
+		FKOnDelete: pg.FKActionNoAction,
+		FKOnUpdate: pg.FKActionNoAction,
+	}
+	change := kit.Change{
+		Kind:       kit.ChangeAddConstraint,
+		TableName:  "users",
+		Constraint: &constraint,
+	}
+	stmts := kit.GenerateChangeSQL(snap, change)
+	if len(stmts) != 1 {
+		t.Fatalf("expected 1 statement, got %d: %v", len(stmts), stmts)
+	}
+	got := stmts[0]
+	if strings.Contains(got, "ON DELETE") {
+		t.Errorf("unexpected ON DELETE clause for NO ACTION:\n  %s", got)
+	}
+	if strings.Contains(got, "ON UPDATE") {
+		t.Errorf("unexpected ON UPDATE clause for NO ACTION:\n  %s", got)
+	}
+}
+
 // --- Helpers ---
 
 func countKind(changes []kit.Change, kind kit.ChangeKind) int {

--- a/kit/kit_test.go
+++ b/kit/kit_test.go
@@ -518,6 +518,35 @@ func TestMySQLChangeSQL_DropIndex(t *testing.T) {
 	}
 }
 
+func TestMySQLChangeSQL_AddFKWithOnUpdate(t *testing.T) {
+	snap := kit.FromDefs(realmsDef)
+	constraint := pg.Constraint{
+		Kind:       pg.KindForeignKey,
+		Name:       "users_realm_fk",
+		Columns:    []string{"realm_id"},
+		FKTable:    "realms",
+		FKColumns:  []string{"id"},
+		FKOnDelete: pg.FKActionCascade,
+		FKOnUpdate: pg.FKActionCascade,
+	}
+	change := kit.Change{
+		Kind:       kit.ChangeAddConstraint,
+		TableName:  "users",
+		Constraint: &constraint,
+	}
+	stmts := kit.GenerateChangeSQLMySQL(snap, change)
+	if len(stmts) != 1 {
+		t.Fatalf("expected 1 statement, got %d: %v", len(stmts), stmts)
+	}
+	got := stmts[0]
+	if !strings.Contains(got, "ON DELETE CASCADE") {
+		t.Errorf("missing ON DELETE CASCADE in:\n  %s", got)
+	}
+	if !strings.Contains(got, "ON UPDATE CASCADE") {
+		t.Errorf("missing ON UPDATE CASCADE in:\n  %s", got)
+	}
+}
+
 func TestMySQLChangeSQL_AlterColumnType(t *testing.T) {
 	snap := kit.FromDefs(realmsDef)
 	newCol := pg.ColumnDef{Name: "name", SQLType: "varchar(512)", NotNull: true}

--- a/kit/sqlgen.go
+++ b/kit/sqlgen.go
@@ -422,6 +422,9 @@ func addConstraintSQL(tableName string, c pg.Constraint) []string {
 		if c.FKOnDelete != "" && c.FKOnDelete != pg.FKActionNoAction {
 			sql += " ON DELETE " + string(c.FKOnDelete)
 		}
+		if c.FKOnUpdate != "" && c.FKOnUpdate != pg.FKActionNoAction {
+			sql += " ON UPDATE " + string(c.FKOnUpdate)
+		}
 		return []string{sql}
 	}
 	return nil

--- a/kit/sqlgen_mysql.go
+++ b/kit/sqlgen_mysql.go
@@ -333,6 +333,9 @@ func addConstraintSQLMySQL(tableName string, c pg.Constraint) []string {
 		if c.FKOnDelete != "" && c.FKOnDelete != pg.FKActionNoAction {
 			sql += " ON DELETE " + string(c.FKOnDelete)
 		}
+		if c.FKOnUpdate != "" && c.FKOnUpdate != pg.FKActionNoAction {
+			sql += " ON UPDATE " + string(c.FKOnUpdate)
+		}
 		return []string{sql}
 	}
 	return nil


### PR DESCRIPTION
## Summary

- `addConstraintSQL` in `kit/sqlgen.go` was silently dropping the `ON UPDATE` action for FK constraints in `ALTER TABLE ADD CONSTRAINT` statements
- `addConstraintSQLMySQL` in `kit/sqlgen_mysql.go` had the same omission
- `createTableSQL` correctly emitted both `ON DELETE` and `ON UPDATE`; both `addConstraintSQL` functions only emitted `ON DELETE`
- Any FK with a non-default `ON UPDATE` action (e.g. `CASCADE`, `RESTRICT`, `SET NULL`) was respected at schema-creation time but silently lost when the FK was added via a migration step

## Changes

- `kit/sqlgen.go`: Added the missing `ON UPDATE` clause to the `pg.KindForeignKey` case in `addConstraintSQL`, matching the existing pattern in `createTableSQL` — `NO ACTION` is suppressed to keep SQL clean
- `kit/sqlgen_mysql.go`: Same fix applied to `addConstraintSQLMySQL`
- `kit/kit_test.go`: Added four regression tests:
  - `TestGenerateChangeSQL_AddFKWithOnUpdate` — PostgreSQL FK with both `ON DELETE CASCADE` and `ON UPDATE CASCADE` via migration emits both clauses
  - `TestGenerateChangeSQL_AddFKWithOnUpdateOnly` — PostgreSQL FK with only `ON UPDATE RESTRICT` emits `ON UPDATE` but not `ON DELETE`
  - `TestGenerateChangeSQL_AddFKDefaultActions` — FK with `NO ACTION` on both emits neither clause
  - `TestMySQLChangeSQL_AddFKWithOnUpdate` — MySQL FK with both actions emits both clauses

## Test plan

- [x] All four new regression tests pass
- [x] Full `go test ./...` passes across Go 1.24, 1.25, 1.26 with no regressions
- [x] CI green

## Deferred

- #258: Add in-repo CHANGELOG (no changelog exists in the project; deferred as a documentation project)

Closes #229