### PR TITLE
chore: bump minimum Go to 1.25 and upgrade pgx to 5.9.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ["1.24", "1.25", "1.26"]
+        go: ["1.25", "1.26"]
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -37,7 +37,7 @@ jobs:
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: "1.24"
+          go-version: "1.25"
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Grizzle generates Go structs that mirror your database schema. Every column is a
 
 ## Installation
 
+**Requires Go 1.25 or later.**
+
 ```sh
 go get github.com/sofired/grizzle
 ```

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -2,6 +2,8 @@
 
 ## Installation
 
+**Requires Go 1.25 or later.**
+
 Add Grizzle to your Go module:
 
 ```sh

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,11 @@
 module github.com/sofired/grizzle
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/go-sql-driver/mysql v1.10.0
 	github.com/google/uuid v1.6.0
-	github.com/jackc/pgx/v5 v5.8.0
+	github.com/jackc/pgx/v5 v5.9.2
 	github.com/mattn/go-sqlite3 v1.14.44
 )
 

--- a/go.sum
+++ b/go.sum
@@ -11,8 +11,6 @@ github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsI
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761/go.mod h1:5TJZWKEWniPve33vlWYSoGYefn3gLQRzjfDlhSJ9ZKM=
-github.com/jackc/pgx/v5 v5.8.0 h1:TYPDoleBBme0xGSAX3/+NujXXtpZn9HBONkQC7IEZSo=
-github.com/jackc/pgx/v5 v5.8.0/go.mod h1:QVeDInX2m9VyzvNeiCJVjCkNFqzsNb43204HshNSZKw=
 github.com/jackc/pgx/v5 v5.9.2 h1:3ZhOzMWnR4yJ+RW1XImIPsD1aNSz4T4fyP7zlQb56hw=
 github.com/jackc/pgx/v5 v5.9.2/go.mod h1:mal1tBGAFfLHvZzaYh77YS/eC6IX9OWbRV1QIIM0Jn4=
 github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo=

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,8 @@ github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7Ulw
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761/go.mod h1:5TJZWKEWniPve33vlWYSoGYefn3gLQRzjfDlhSJ9ZKM=
 github.com/jackc/pgx/v5 v5.8.0 h1:TYPDoleBBme0xGSAX3/+NujXXtpZn9HBONkQC7IEZSo=
 github.com/jackc/pgx/v5 v5.8.0/go.mod h1:QVeDInX2m9VyzvNeiCJVjCkNFqzsNb43204HshNSZKw=
+github.com/jackc/pgx/v5 v5.9.2 h1:3ZhOzMWnR4yJ+RW1XImIPsD1aNSz4T4fyP7zlQb56hw=
+github.com/jackc/pgx/v5 v5.9.2/go.mod h1:mal1tBGAFfLHvZzaYh77YS/eC6IX9OWbRV1QIIM0Jn4=
 github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo=
 github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/mattn/go-sqlite3 v1.14.44 h1:3VSe+xafpbzsLbdr2AWlAZk9yRHiBhTBakioXaCKTF8=


### PR DESCRIPTION
## Summary

- `go.mod`: Bumps minimum Go version from `1.24.0` to `1.25.0`, satisfying pgx v5.9.x's requirement
- `pgx`: Upgraded from `v5.8.0` to `v5.9.2`, picking up two important fixes:
  - Batch result format corruption with cached prepared statements (relevant to Grizzle's `QueryExecModeCacheStatement` usage)
  - SQL injection fix for dollar-quoted string placeholder confusion (GHSA-j88v-2chj-qfwx)
- `go.sum`: Ran `go mod tidy` to remove stale v5.8.0 entries
- `README.md`, `docs/guide/getting-started.md`: Added "Requires Go 1.25 or later" note to Installation sections
- All existing tests pass on Go 1.25 (`go test -count=1 ./...`)

## CI matrix update (needs maintainer push)

The bot account (`charles-fineman`) lacks the `workflow` OAuth scope required to push `.github/workflows/ci.yml`. The following two-line change has been prepared locally and needs to be applied by a maintainer:

```diff
-        go: ["1.24", "1.25", "1.26"]
+        go: ["1.25", "1.26"]
```
```diff
-          go-version: "1.24"
+          go-version: "1.25"
```

To apply, a maintainer can either:
- Grant the `workflow` scope to the bot (`gh auth refresh --hostname github.com --scopes workflow`) and re-push, **or**
- Apply the two-line diff manually and commit it to this branch

## Peer Review Summary

All four peer reviews completed:
- **Security**: APPROVED — no vulnerabilities introduced; GHSA-j88v-2chj-qfwx mitigated (Grizzle was not directly exposed since it never uses `QueryExecModeSimpleProtocol`)
- **Documentation**: APPROVED WITH NOTES — Go version requirement added to README and getting-started guide; security fix noted for release notes
- **Backend**: APPROVED — `go mod tidy` cleanup done; pgx v5.9.2 API-compatible; all compile-time interface assertions pass
- **Testing**: APPROVED WITH NOTES — pre-existing gaps captured in follow-up issues #267 and #268

## Follow-up Issues Created

- #267: Add unit tests for `ScanOne`/`ScanOneOpt` error paths in pgx driver
- #268: Add unit test for `Transaction` rollback path in pgx driver

## Acceptance Criteria Status

- [x] `go.mod` declares `go 1.25` (or later) — now `go 1.25.0`
- [ ] CI matrix updated: Go 1.24 lane removed, Go 1.25 and Go 1.26 lanes confirmed passing *(needs maintainer push — see above)*
- [x] Dependabot pgx 5.9.x ignore rule removed *(was never added to `dependabot.yml` — #212 was closed without adding an ignore rule)*
- [x] pgx upgraded to 5.9.2
- [x] All existing tests pass on Go 1.25

Closes #227