### PR TITLE
test(filemigrate): pin CombinedSHA256 artifact digest formula

### DIFF
--- a/kit/filemigrate/artifact_digest_test.go
+++ b/kit/filemigrate/artifact_digest_test.go
@@ -44,7 +44,13 @@ type combinedGoldenVector struct {
 	wantHex string
 }
 
-// goldenCombinedVectors are independently computed via Python:
+// goldenCombinedVectors are independently computed by a Python reference
+// implementation in testdata/digest_reference.py. Run that script to
+// regenerate goldens after any deliberate, spec-amending change to the
+// digest formula; do NOT regenerate them from the Go production code, since
+// the cross-implementation match is what pins the wire format here.
+//
+// The script (and the inline formula it documents) is:
 //
 //	h = hashlib.sha256()
 //	h.update(b'grizzle-artifact-v1'); h.update(b'\x00')

--- a/kit/filemigrate/artifact_digest_test.go
+++ b/kit/filemigrate/artifact_digest_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/binary"
 	"encoding/hex"
+	"fmt"
 	"testing"
 
 	"github.com/sofired/grizzle/kit/filemigrate"
@@ -102,7 +103,6 @@ var goldenCombinedVectors = []combinedGoldenVector{
 	},
 }
 
-// fullByteRange returns the 256-byte slice 0x00, 0x01, ..., 0xFF.
 func fullByteRange() []byte {
 	out := make([]byte, 256)
 	for i := range out {
@@ -212,7 +212,7 @@ func TestArtifactDigest_PerFileGoldenVectors(t *testing.T) {
 			sql:         fullByteRange(),
 			snap:        []byte(`{"v":"1"}`),
 			wantSQLHex:  "40aff2e9d2d8922e47afd4648e6967497158785fbd1da870e7110266bf944880",
-			wantSnapHex: "", // computed below; cross-check via raw sha256 since snap is short
+			wantSnapHex: "b8513f1a0c28d8dd9b3b175bee09eabca97c4819614ec9a2df7442a5b4eff8d7",
 		},
 	}
 	store := filemigrate.NewMemArtifactStore()
@@ -226,20 +226,9 @@ func TestArtifactDigest_PerFileGoldenVectors(t *testing.T) {
 			if gotSQLHex != tc.wantSQLHex {
 				t.Errorf("MigrationSQLSHA256 mismatch\n  got:  %s\n  want: %s", gotSQLHex, tc.wantSQLHex)
 			}
-
 			gotSnapHex := hex.EncodeToString(loaded.Digests.SnapshotJSONSHA256[:])
-			if tc.wantSnapHex != "" {
-				if gotSnapHex != tc.wantSnapHex {
-					t.Errorf("SnapshotJSONSHA256 mismatch\n  got:  %s\n  want: %s", gotSnapHex, tc.wantSnapHex)
-				}
-			} else {
-				// Fall back to recomputing with stdlib for cases where a hand-
-				// pinned snapshot hex would be redundant.
-				want := sha256.Sum256(tc.snap)
-				if loaded.Digests.SnapshotJSONSHA256 != filemigrate.Digest(want) {
-					t.Errorf("SnapshotJSONSHA256 mismatch\n  got:  %s\n  want: %s",
-						gotSnapHex, hex.EncodeToString(want[:]))
-				}
+			if gotSnapHex != tc.wantSnapHex {
+				t.Errorf("SnapshotJSONSHA256 mismatch\n  got:  %s\n  want: %s", gotSnapHex, tc.wantSnapHex)
 			}
 		})
 	}
@@ -332,13 +321,9 @@ func TestArtifactDigest_RoundtripsThroughRead(t *testing.T) {
 	}
 }
 
-// makeTestArtifactName builds a deterministic, validation-passing migration
-// directory name for the i-th vector. The names are unique per call so that
-// CreateArtifact does not reject duplicates inside a single store instance.
+// makeTestArtifactName builds a unique, validation-passing migration directory
+// name for the i-th vector. Callers offset i across test functions so that
+// CreateArtifact does not see duplicates within a single shared store.
 func makeTestArtifactName(i int) string {
-	const digits = "0123456789"
-	// Build "20240101000000_v<NN>" with i zero-padded to width 4. We avoid
-	// fmt.Sprintf to keep this helper trivial and dependency-free.
-	pad := []byte{digits[(i/1000)%10], digits[(i/100)%10], digits[(i/10)%10], digits[i%10]}
-	return "20240101000000_v" + string(pad)
+	return fmt.Sprintf("20240101000000_v%04d", i)
 }

--- a/kit/filemigrate/artifact_digest_test.go
+++ b/kit/filemigrate/artifact_digest_test.go
@@ -44,6 +44,11 @@ type combinedGoldenVector struct {
 	wantHex string
 }
 
+const (
+	normalizationSensitiveSQL  = "-- café\r\nSELECT '雪';\r\n"
+	normalizationSensitiveSnap = "{\r\n  \"note\": \"naïve 東京\"\r\n}\r\n"
+)
+
 // goldenCombinedVectors are independently computed by a Python reference
 // implementation in testdata/digest_reference.py. Run that script to
 // regenerate goldens after any deliberate, spec-amending change to the
@@ -62,7 +67,7 @@ type combinedGoldenVector struct {
 //
 // Any change to the spec byte layout (separator byte, domain string, label
 // strings, label order, endianness, length-prefix width, or omission of any
-// component) will cause every vector below to flip, failing this test loudly.
+// component) should make at least one vector below fail loudly.
 var goldenCombinedVectors = []combinedGoldenVector{
 	{
 		name:    "both_empty",
@@ -75,6 +80,15 @@ var goldenCombinedVectors = []combinedGoldenVector{
 		sql:     []byte("CREATE TABLE t (id INT);"),
 		snap:    []byte(`{"version":"1"}`),
 		wantHex: "0cafd83a585887b16d54263041c29c3309bd35a85068ad21a420d988a40ac95d",
+	},
+	{
+		// Valid UTF-8 SQL and JSON with a SQL comment, CRLF line endings,
+		// and trailing newlines. The golden pins those exact raw bytes so
+		// hashing cannot silently normalize text-shaped artifact content.
+		name:    "utf8_comments_crlf_trailing_newlines",
+		sql:     []byte(normalizationSensitiveSQL),
+		snap:    []byte(normalizationSensitiveSnap),
+		wantHex: "6726bbd011c3b92f787fca83aed435200df6f92552dda4f3e075e9b06fb8b26d",
 	},
 	{
 		name:    "empty_sql_with_snap",
@@ -99,9 +113,8 @@ var goldenCombinedVectors = []combinedGoldenVector{
 		wantHex: "65c1350c4e33e8986cda857b9b0bfab3643ca88694873b7de47558663dbc4d92",
 	},
 	{
-		// 1 KiB of zero bytes for both payloads — exercises the length-prefix
-		// path with a payload that is otherwise indistinguishable from absence
-		// without the length header.
+		// 1 KiB of zero bytes for both payloads exercises embedded NUL bytes
+		// together with a multi-byte big-endian length.
 		name:    "zeros_1024_each",
 		sql:     bytes.Repeat([]byte{0x00}, 1024),
 		snap:    bytes.Repeat([]byte{0x00}, 1024),
@@ -167,7 +180,7 @@ func TestArtifactDigest_CombinedByteAssembly(t *testing.T) {
 			buf.Write(v.snap)
 			want := sha256.Sum256(buf.Bytes())
 
-			name := makeTestArtifactName(i + len(goldenCombinedVectors))
+			name := makeTestArtifactName(i)
 			loaded := mustCreateArtifact(t, store, root, name, v.sql, v.snap)
 			if loaded.Digests.CombinedSHA256 != filemigrate.Digest(want) {
 				t.Errorf("CombinedSHA256 mismatch with byte-assembly\n  got:  %s\n  want: %s",
@@ -179,11 +192,10 @@ func TestArtifactDigest_CombinedByteAssembly(t *testing.T) {
 }
 
 // TestArtifactDigest_PerFileGoldenVectors locks the exact per-file SHA-256
-// values for known inputs. Per-file digests are plain SHA-256 over raw bytes
-// (no domain prefix, no length framing) per
-// docs/spec/file-migrations-artifacts.md:528-536. The MigrationSQLSHA256 is
+// values for known inputs. These tests pin per-file digests as plain SHA-256
+// over raw bytes with no domain prefix or length framing. MigrationSQLSHA256 is
 // what the DB history table records as `hash` for Drizzle RC.1 alignment, so
-// any drift here would corrupt cross-version history reads.
+// any drift here would break history-hash compatibility.
 func TestArtifactDigest_PerFileGoldenVectors(t *testing.T) {
 	cases := []struct {
 		name        string
@@ -198,6 +210,13 @@ func TestArtifactDigest_PerFileGoldenVectors(t *testing.T) {
 			snap:        []byte(`{"version":"1"}`),
 			wantSQLHex:  "f423e61fbd021a13b6ae0afb423f2da5c3cf7cc0647ddb7348266dbfd281d6fe",
 			wantSnapHex: "aa5bc61f44d5f633935d04cbccf2654c56806fc924b0083a6cb6b7545369ad64",
+		},
+		{
+			name:        "utf8_comments_crlf_trailing_newlines",
+			sql:         []byte(normalizationSensitiveSQL),
+			snap:        []byte(normalizationSensitiveSnap),
+			wantSQLHex:  "7eea9d1e2389949ca151a38a802209a7f661b78cd54f530ca585a7456d2d20e2",
+			wantSnapHex: "0eee986c58412baf4d16e1646ae79459247e7e40d4161df0a2fab705bb1b30fd",
 		},
 		{
 			name:        "select1_with_empty_obj",
@@ -225,7 +244,7 @@ func TestArtifactDigest_PerFileGoldenVectors(t *testing.T) {
 	root := mustResolveRoot(t, store, "/m", filemigrate.RootEnsureForWrite)
 	for i, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			name := makeTestArtifactName(i + 2*len(goldenCombinedVectors))
+			name := makeTestArtifactName(i)
 			loaded := mustCreateArtifact(t, store, root, name, tc.sql, tc.snap)
 
 			gotSQLHex := hex.EncodeToString(loaded.Digests.MigrationSQLSHA256[:])
@@ -240,10 +259,9 @@ func TestArtifactDigest_PerFileGoldenVectors(t *testing.T) {
 	}
 }
 
-// TestArtifactDigest_CombinedSwapDistinguishable verifies that swapping the
-// two payloads produces a different combined digest. This guards against an
-// implementation that drops the labels or treats the two sections as
-// interchangeable. The two inputs are byte-distinct, so the swap is observable.
+// TestArtifactDigest_CombinedSwapDistinguishable verifies that the combined
+// digest is sensitive to payload role and order. The two inputs are
+// byte-distinct, so the swap is observable.
 func TestArtifactDigest_CombinedSwapDistinguishable(t *testing.T) {
 	store := filemigrate.NewMemArtifactStore()
 	root := mustResolveRoot(t, store, "/m", filemigrate.RootEnsureForWrite)
@@ -259,24 +277,69 @@ func TestArtifactDigest_CombinedSwapDistinguishable(t *testing.T) {
 	}
 }
 
-// TestArtifactDigest_CombinedLengthFramingDistinguishable verifies that the
-// uint64be length prefix actually distinguishes inputs that would otherwise
-// collide under naive concatenation. The pair below has the same total payload
-// bytes but different splits between migration.sql and snapshot.json, and must
-// produce different combined digests.
-func TestArtifactDigest_CombinedLengthFramingDistinguishable(t *testing.T) {
-	store := filemigrate.NewMemArtifactStore()
-	root := mustResolveRoot(t, store, "/m", filemigrate.RootEnsureForWrite)
+// TestArtifactDigest_RawBytesAreNotNormalized proves that text-shaped artifacts
+// are hashed as raw bytes. Each pair differs by exactly one normalization a
+// caller might otherwise be tempted to apply.
+func TestArtifactDigest_RawBytesAreNotNormalized(t *testing.T) {
+	cases := []struct {
+		name         string
+		sqlA, sqlB   []byte
+		snapA, snapB []byte
+	}{
+		{
+			name:  "migration_sql_lf_vs_crlf",
+			sqlA:  []byte("-- café\nSELECT '雪';\n"),
+			sqlB:  []byte("-- café\r\nSELECT '雪';\r\n"),
+			snapA: []byte(`{"note":"naïve"}`),
+			snapB: []byte(`{"note":"naïve"}`),
+		},
+		{
+			name:  "snapshot_json_lf_vs_crlf",
+			sqlA:  []byte("SELECT 1;"),
+			sqlB:  []byte("SELECT 1;"),
+			snapA: []byte("{\n  \"note\": \"naïve\"\n}\n"),
+			snapB: []byte("{\r\n  \"note\": \"naïve\"\r\n}\r\n"),
+		},
+		{
+			name:  "migration_sql_comment_retained",
+			sqlA:  []byte("-- café\nSELECT '雪';"),
+			sqlB:  []byte("SELECT '雪';"),
+			snapA: []byte(`{"note":"naïve"}`),
+			snapB: []byte(`{"note":"naïve"}`),
+		},
+		{
+			name:  "migration_sql_trailing_newline_retained",
+			sqlA:  []byte("SELECT '雪';"),
+			sqlB:  []byte("SELECT '雪';\n"),
+			snapA: []byte(`{"note":"naïve"}`),
+			snapB: []byte(`{"note":"naïve"}`),
+		},
+		{
+			name:  "snapshot_json_trailing_newline_retained",
+			sqlA:  []byte("SELECT 1;"),
+			sqlB:  []byte("SELECT 1;"),
+			snapA: []byte(`{"note":"naïve"}`),
+			snapB: []byte("{\"note\":\"naïve\"}\n"),
+		},
+	}
 
-	a := mustCreateArtifact(t, store, root, "20240101000000_a",
-		[]byte("AAA"), []byte("B"))
-	b := mustCreateArtifact(t, store, root, "20240101000000_b",
-		[]byte("AA"), []byte("AB"))
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			store := filemigrate.NewMemArtifactStore()
+			root := mustResolveRoot(t, store, "/m", filemigrate.RootEnsureForWrite)
+			a := mustCreateArtifact(t, store, root, "20240101000000_a", tc.sqlA, tc.snapA)
+			b := mustCreateArtifact(t, store, root, "20240101000000_b", tc.sqlB, tc.snapB)
 
-	if a.Digests.CombinedSHA256 == b.Digests.CombinedSHA256 {
-		t.Errorf("length framing must distinguish (sql=%q,snap=%q) from (sql=%q,snap=%q), got identical %s",
-			"AAA", "B", "AA", "AB",
-			hex.EncodeToString(a.Digests.CombinedSHA256[:]))
+			if !bytes.Equal(tc.sqlA, tc.sqlB) && a.Digests.MigrationSQLSHA256 == b.Digests.MigrationSQLSHA256 {
+				t.Error("raw migration.sql byte variants must have distinct per-file digests")
+			}
+			if !bytes.Equal(tc.snapA, tc.snapB) && a.Digests.SnapshotJSONSHA256 == b.Digests.SnapshotJSONSHA256 {
+				t.Error("raw snapshot.json byte variants must have distinct per-file digests")
+			}
+			if a.Digests.CombinedSHA256 == b.Digests.CombinedSHA256 {
+				t.Error("raw artifact byte variants must have distinct combined digests")
+			}
+		})
 	}
 }
 
@@ -300,10 +363,8 @@ func TestArtifactDigest_CombinedDeterministic(t *testing.T) {
 	}
 }
 
-// TestArtifactDigest_RoundtripsThroughRead pins that ReadArtifact reproduces
-// the same digests that CreateArtifact emitted. This rules out a class of bug
-// where digests are computed only on the write path (or only on the read
-// path), or where the read path silently rehashes from a normalized buffer.
+// TestArtifactDigest_RoundtripsThroughRead pins digest consistency for
+// unchanged bytes across MemArtifactStore CreateArtifact and ReadArtifact.
 func TestArtifactDigest_RoundtripsThroughRead(t *testing.T) {
 	store := filemigrate.NewMemArtifactStore()
 	root := mustResolveRoot(t, store, "/m", filemigrate.RootEnsureForWrite)
@@ -328,8 +389,7 @@ func TestArtifactDigest_RoundtripsThroughRead(t *testing.T) {
 }
 
 // makeTestArtifactName builds a unique, validation-passing migration directory
-// name for the i-th vector. Callers offset i across test functions so that
-// CreateArtifact does not see duplicates within a single shared store.
+// name for the i-th vector within a test-local store.
 func makeTestArtifactName(i int) string {
 	return fmt.Sprintf("20240101000000_v%04d", i)
 }

--- a/kit/filemigrate/artifact_digest_test.go
+++ b/kit/filemigrate/artifact_digest_test.go
@@ -1,0 +1,344 @@
+package filemigrate_test
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"testing"
+
+	"github.com/sofired/grizzle/kit/filemigrate"
+)
+
+// Spec references for ArtifactDigest.CombinedSHA256:
+//
+//   - docs/spec/file-migrations-api.md:363-373
+//   - docs/spec/file-migrations-artifacts.md:528-536
+//
+// The formula is:
+//
+//	SHA256(
+//	  "grizzle-artifact-v1" || 0x00 ||
+//	  "migration.sql" || 0x00 || uint64be(len(migration.sql)) || raw migration.sql bytes ||
+//	  "snapshot.json" || 0x00 || uint64be(len(snapshot.json)) || raw snapshot.json bytes
+//	)
+//
+// The tests in this file pin that exact byte layout. Two independent layers of
+// conformance are exercised:
+//
+//  1. Golden hex vectors — pre-computed offline with a different language/runtime
+//     (Python's hashlib). These catch any change to the formula, including
+//     endianness flips, separator swaps, payload reordering, or label edits.
+//  2. Byte-assembly — re-derive the byte stream inside the test using stdlib
+//     primitives that do not share code with the implementation, then hash it
+//     and compare. This catches behavioral drift even if the goldens get
+//     updated without independent recomputation.
+
+// combinedGoldenVector is one (sql, snap, expected combined hex) triple
+// pre-computed independently of the production implementation.
+type combinedGoldenVector struct {
+	name    string
+	sql     []byte
+	snap    []byte
+	wantHex string
+}
+
+// goldenCombinedVectors are independently computed via Python:
+//
+//	h = hashlib.sha256()
+//	h.update(b'grizzle-artifact-v1'); h.update(b'\x00')
+//	h.update(b'migration.sql');       h.update(b'\x00')
+//	h.update(struct.pack('>Q', len(sql))); h.update(sql)
+//	h.update(b'snapshot.json');       h.update(b'\x00')
+//	h.update(struct.pack('>Q', len(snap))); h.update(snap)
+//	h.hexdigest()
+//
+// Any change to the spec byte layout (separator byte, domain string, label
+// strings, label order, endianness, length-prefix width, or omission of any
+// component) will cause every vector below to flip, failing this test loudly.
+var goldenCombinedVectors = []combinedGoldenVector{
+	{
+		name:    "both_empty",
+		sql:     []byte(""),
+		snap:    []byte(""),
+		wantHex: "a3c7cae6b5098053bcd8fec18a37d4e257278db8c4fd851dcc9d0c86cc707852",
+	},
+	{
+		name:    "small_ascii",
+		sql:     []byte("CREATE TABLE t (id INT);"),
+		snap:    []byte(`{"version":"1"}`),
+		wantHex: "0cafd83a585887b16d54263041c29c3309bd35a85068ad21a420d988a40ac95d",
+	},
+	{
+		name:    "empty_sql_with_snap",
+		sql:     []byte(""),
+		snap:    []byte("{}"),
+		wantHex: "ebd7e42d73531a9252aac54d14e4961e2ae205a0c24e73585eba36a4334fcf02",
+	},
+	{
+		name:    "empty_snap_with_sql",
+		sql:     []byte("SELECT 1;"),
+		snap:    []byte(""),
+		wantHex: "aadbc247869c70cfb56f3d7c942340cb409fe113714eac88035c7c8d66f459e6",
+	},
+	{
+		// 256-byte sequence covering every byte value, paired with a snapshot
+		// containing 0x00 and 0xFF runs. Any single-byte misencoding in the
+		// content path (e.g. mis-stripping 0x00 inside payload, treating the
+		// payload as a C string) would flip this digest.
+		name:    "full_byte_range_with_zeros_and_high_bytes",
+		sql:     fullByteRange(),
+		snap:    append(bytes.Repeat([]byte{0xff}, 100), bytes.Repeat([]byte{0x00}, 50)...),
+		wantHex: "65c1350c4e33e8986cda857b9b0bfab3643ca88694873b7de47558663dbc4d92",
+	},
+	{
+		// 1 KiB of zero bytes for both payloads — exercises the length-prefix
+		// path with a payload that is otherwise indistinguishable from absence
+		// without the length header.
+		name:    "zeros_1024_each",
+		sql:     bytes.Repeat([]byte{0x00}, 1024),
+		snap:    bytes.Repeat([]byte{0x00}, 1024),
+		wantHex: "aa9060b3befac5d93f98d046517e93bebcf336c1471ae8851ff37f6042f2947b",
+	},
+}
+
+// fullByteRange returns the 256-byte slice 0x00, 0x01, ..., 0xFF.
+func fullByteRange() []byte {
+	out := make([]byte, 256)
+	for i := range out {
+		out[i] = byte(i)
+	}
+	return out
+}
+
+// TestArtifactDigest_CombinedGoldenVectors locks the exact CombinedSHA256
+// output for several inputs against hex values computed independently with
+// Python's hashlib. Treat any mismatch as a spec-breaking change to the
+// digest formula and stop the build — published artifact digests must remain
+// stable across releases.
+func TestArtifactDigest_CombinedGoldenVectors(t *testing.T) {
+	store := filemigrate.NewMemArtifactStore()
+	root := mustResolveRoot(t, store, "/m", filemigrate.RootEnsureForWrite)
+
+	for i, v := range goldenCombinedVectors {
+		t.Run(v.name, func(t *testing.T) {
+			// Use a unique directory name per vector since CreateArtifact is
+			// the only public surface that exposes the populated digest.
+			name := makeTestArtifactName(i)
+			loaded := mustCreateArtifact(t, store, root, name, v.sql, v.snap)
+			gotHex := hex.EncodeToString(loaded.Digests.CombinedSHA256[:])
+			if gotHex != v.wantHex {
+				t.Errorf("CombinedSHA256 mismatch\n  got:  %s\n  want: %s", gotHex, v.wantHex)
+			}
+		})
+	}
+}
+
+// TestArtifactDigest_CombinedByteAssembly independently rebuilds the spec
+// byte stream using stdlib primitives and confirms its SHA-256 equals the
+// CombinedSHA256 returned by the store. This is a layered check on top of
+// the golden hex vectors: if the goldens drift, byte-assembly still pins the
+// algorithm; if the assembly drifts, the goldens still pin the digests.
+func TestArtifactDigest_CombinedByteAssembly(t *testing.T) {
+	store := filemigrate.NewMemArtifactStore()
+	root := mustResolveRoot(t, store, "/m", filemigrate.RootEnsureForWrite)
+
+	for i, v := range goldenCombinedVectors {
+		t.Run(v.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			buf.WriteString("grizzle-artifact-v1")
+			buf.WriteByte(0x00)
+			buf.WriteString("migration.sql")
+			buf.WriteByte(0x00)
+			var lenBuf [8]byte
+			binary.BigEndian.PutUint64(lenBuf[:], uint64(len(v.sql)))
+			buf.Write(lenBuf[:])
+			buf.Write(v.sql)
+			buf.WriteString("snapshot.json")
+			buf.WriteByte(0x00)
+			binary.BigEndian.PutUint64(lenBuf[:], uint64(len(v.snap)))
+			buf.Write(lenBuf[:])
+			buf.Write(v.snap)
+			want := sha256.Sum256(buf.Bytes())
+
+			name := makeTestArtifactName(i + len(goldenCombinedVectors))
+			loaded := mustCreateArtifact(t, store, root, name, v.sql, v.snap)
+			if loaded.Digests.CombinedSHA256 != filemigrate.Digest(want) {
+				t.Errorf("CombinedSHA256 mismatch with byte-assembly\n  got:  %s\n  want: %s",
+					hex.EncodeToString(loaded.Digests.CombinedSHA256[:]),
+					hex.EncodeToString(want[:]))
+			}
+		})
+	}
+}
+
+// TestArtifactDigest_PerFileGoldenVectors locks the exact per-file SHA-256
+// values for known inputs. Per-file digests are plain SHA-256 over raw bytes
+// (no domain prefix, no length framing) per
+// docs/spec/file-migrations-artifacts.md:528-536. The MigrationSQLSHA256 is
+// what the DB history table records as `hash` for Drizzle RC.1 alignment, so
+// any drift here would corrupt cross-version history reads.
+func TestArtifactDigest_PerFileGoldenVectors(t *testing.T) {
+	cases := []struct {
+		name        string
+		sql         []byte
+		snap        []byte
+		wantSQLHex  string
+		wantSnapHex string
+	}{
+		{
+			name:        "small_ascii",
+			sql:         []byte("CREATE TABLE t (id INT);"),
+			snap:        []byte(`{"version":"1"}`),
+			wantSQLHex:  "f423e61fbd021a13b6ae0afb423f2da5c3cf7cc0647ddb7348266dbfd281d6fe",
+			wantSnapHex: "aa5bc61f44d5f633935d04cbccf2654c56806fc924b0083a6cb6b7545369ad64",
+		},
+		{
+			name:        "select1_with_empty_obj",
+			sql:         []byte("SELECT 1;"),
+			snap:        []byte("{}"),
+			wantSQLHex:  "17db4fd369edb9244b9f91d9aeed145c3d04ad8ba6e95d06247f07a63527d11a",
+			wantSnapHex: "44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
+		},
+		{
+			name:        "empty_inputs",
+			sql:         []byte(""),
+			snap:        []byte(""),
+			wantSQLHex:  "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+			wantSnapHex: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+		},
+		{
+			name:        "full_byte_range_sql",
+			sql:         fullByteRange(),
+			snap:        []byte(`{"v":"1"}`),
+			wantSQLHex:  "40aff2e9d2d8922e47afd4648e6967497158785fbd1da870e7110266bf944880",
+			wantSnapHex: "", // computed below; cross-check via raw sha256 since snap is short
+		},
+	}
+	store := filemigrate.NewMemArtifactStore()
+	root := mustResolveRoot(t, store, "/m", filemigrate.RootEnsureForWrite)
+	for i, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			name := makeTestArtifactName(i + 2*len(goldenCombinedVectors))
+			loaded := mustCreateArtifact(t, store, root, name, tc.sql, tc.snap)
+
+			gotSQLHex := hex.EncodeToString(loaded.Digests.MigrationSQLSHA256[:])
+			if gotSQLHex != tc.wantSQLHex {
+				t.Errorf("MigrationSQLSHA256 mismatch\n  got:  %s\n  want: %s", gotSQLHex, tc.wantSQLHex)
+			}
+
+			gotSnapHex := hex.EncodeToString(loaded.Digests.SnapshotJSONSHA256[:])
+			if tc.wantSnapHex != "" {
+				if gotSnapHex != tc.wantSnapHex {
+					t.Errorf("SnapshotJSONSHA256 mismatch\n  got:  %s\n  want: %s", gotSnapHex, tc.wantSnapHex)
+				}
+			} else {
+				// Fall back to recomputing with stdlib for cases where a hand-
+				// pinned snapshot hex would be redundant.
+				want := sha256.Sum256(tc.snap)
+				if loaded.Digests.SnapshotJSONSHA256 != filemigrate.Digest(want) {
+					t.Errorf("SnapshotJSONSHA256 mismatch\n  got:  %s\n  want: %s",
+						gotSnapHex, hex.EncodeToString(want[:]))
+				}
+			}
+		})
+	}
+}
+
+// TestArtifactDigest_CombinedSwapDistinguishable verifies that swapping the
+// two payloads produces a different combined digest. This guards against an
+// implementation that drops the labels or treats the two sections as
+// interchangeable. The two inputs are byte-distinct, so the swap is observable.
+func TestArtifactDigest_CombinedSwapDistinguishable(t *testing.T) {
+	store := filemigrate.NewMemArtifactStore()
+	root := mustResolveRoot(t, store, "/m", filemigrate.RootEnsureForWrite)
+
+	a := mustCreateArtifact(t, store, root, "20240101000000_a",
+		[]byte("payload-A"), []byte("payload-B"))
+	b := mustCreateArtifact(t, store, root, "20240101000000_b",
+		[]byte("payload-B"), []byte("payload-A"))
+
+	if a.Digests.CombinedSHA256 == b.Digests.CombinedSHA256 {
+		t.Errorf("swapping migration.sql and snapshot.json must change CombinedSHA256, got identical %s",
+			hex.EncodeToString(a.Digests.CombinedSHA256[:]))
+	}
+}
+
+// TestArtifactDigest_CombinedLengthFramingDistinguishable verifies that the
+// uint64be length prefix actually distinguishes inputs that would otherwise
+// collide under naive concatenation. The pair below has the same total payload
+// bytes but different splits between migration.sql and snapshot.json, and must
+// produce different combined digests.
+func TestArtifactDigest_CombinedLengthFramingDistinguishable(t *testing.T) {
+	store := filemigrate.NewMemArtifactStore()
+	root := mustResolveRoot(t, store, "/m", filemigrate.RootEnsureForWrite)
+
+	a := mustCreateArtifact(t, store, root, "20240101000000_a",
+		[]byte("AAA"), []byte("B"))
+	b := mustCreateArtifact(t, store, root, "20240101000000_b",
+		[]byte("AA"), []byte("AB"))
+
+	if a.Digests.CombinedSHA256 == b.Digests.CombinedSHA256 {
+		t.Errorf("length framing must distinguish (sql=%q,snap=%q) from (sql=%q,snap=%q), got identical %s",
+			"AAA", "B", "AA", "AB",
+			hex.EncodeToString(a.Digests.CombinedSHA256[:]))
+	}
+}
+
+// TestArtifactDigest_CombinedDeterministic verifies that the combined digest
+// is a pure function of (migration.sql, snapshot.json): repeated creation
+// with the same byte inputs (under different artifact names) yields the same
+// CombinedSHA256. The directory name must not leak into the digest.
+func TestArtifactDigest_CombinedDeterministic(t *testing.T) {
+	store := filemigrate.NewMemArtifactStore()
+	root := mustResolveRoot(t, store, "/m", filemigrate.RootEnsureForWrite)
+
+	sql := []byte("CREATE TABLE t (id INT);")
+	snap := []byte(`{"version":"1"}`)
+
+	a := mustCreateArtifact(t, store, root, "20240101000000_first", sql, snap)
+	b := mustCreateArtifact(t, store, root, "20250202020202_second", sql, snap)
+	if a.Digests.CombinedSHA256 != b.Digests.CombinedSHA256 {
+		t.Errorf("CombinedSHA256 must be deterministic for identical bytes, got %s vs %s",
+			hex.EncodeToString(a.Digests.CombinedSHA256[:]),
+			hex.EncodeToString(b.Digests.CombinedSHA256[:]))
+	}
+}
+
+// TestArtifactDigest_RoundtripsThroughRead pins that ReadArtifact reproduces
+// the same digests that CreateArtifact emitted. This rules out a class of bug
+// where digests are computed only on the write path (or only on the read
+// path), or where the read path silently rehashes from a normalized buffer.
+func TestArtifactDigest_RoundtripsThroughRead(t *testing.T) {
+	store := filemigrate.NewMemArtifactStore()
+	root := mustResolveRoot(t, store, "/m", filemigrate.RootEnsureForWrite)
+
+	sql := []byte("CREATE TABLE t (id INT);\n")
+	snap := []byte(`{"version":"1","dialect":"postgresql"}`)
+	created := mustCreateArtifact(t, store, root, "20240101000000_x", sql, snap)
+
+	got, err := store.ReadArtifact(t.Context(), root, "20240101000000_x", filemigrate.ReadArtifactOptions{})
+	if err != nil {
+		t.Fatalf("ReadArtifact: %v", err)
+	}
+	if got.Digests != created.Digests {
+		t.Errorf("digest mismatch across create/read roundtrip\n  create: combined=%s sql=%s snap=%s\n  read:   combined=%s sql=%s snap=%s",
+			hex.EncodeToString(created.Digests.CombinedSHA256[:]),
+			hex.EncodeToString(created.Digests.MigrationSQLSHA256[:]),
+			hex.EncodeToString(created.Digests.SnapshotJSONSHA256[:]),
+			hex.EncodeToString(got.Digests.CombinedSHA256[:]),
+			hex.EncodeToString(got.Digests.MigrationSQLSHA256[:]),
+			hex.EncodeToString(got.Digests.SnapshotJSONSHA256[:]))
+	}
+}
+
+// makeTestArtifactName builds a deterministic, validation-passing migration
+// directory name for the i-th vector. The names are unique per call so that
+// CreateArtifact does not reject duplicates inside a single store instance.
+func makeTestArtifactName(i int) string {
+	const digits = "0123456789"
+	// Build "20240101000000_v<NN>" with i zero-padded to width 4. We avoid
+	// fmt.Sprintf to keep this helper trivial and dependency-free.
+	pad := []byte{digits[(i/1000)%10], digits[(i/100)%10], digits[(i/10)%10], digits[i%10]}
+	return "20240101000000_v" + string(pad)
+}

--- a/kit/filemigrate/testdata/digest_reference.py
+++ b/kit/filemigrate/testdata/digest_reference.py
@@ -1,7 +1,12 @@
 #!/usr/bin/env python3
-"""Reference implementation of the CombinedSHA256 artifact digest formula.
+"""Reference implementation of the artifact digest formulas.
 
-Spec: docs/spec/file-migrations-api.md:365-371
+Combined formula spec: docs/spec/file-migrations-api.md:365-371
+
+Per-file formulas pinned by this reference:
+
+    MigrationSQLSHA256 = SHA256(raw migration.sql bytes)
+    SnapshotJSONSHA256 = SHA256(raw snapshot.json bytes)
 
     SHA256(
       "grizzle-artifact-v1" || 0x00 ||
@@ -46,11 +51,20 @@ def per_file(content: bytes) -> str:
     return hashlib.sha256(content).hexdigest()
 
 
+NORMALIZATION_SENSITIVE_SQL = "-- café\r\nSELECT '雪';\r\n".encode("utf-8")
+NORMALIZATION_SENSITIVE_SNAP = '{\r\n  "note": "naïve 東京"\r\n}\r\n'.encode("utf-8")
+
+
 # Test vectors pinned by artifact_digest_test.go.
 # Adding a new vector here? Also add the matching Go entry.
 VECTORS = [
     ("both_empty", b"", b""),
     ("small_ascii", b"CREATE TABLE t (id INT);", b'{"version":"1"}'),
+    (
+        "utf8_comments_crlf_trailing_newlines",
+        NORMALIZATION_SENSITIVE_SQL,
+        NORMALIZATION_SENSITIVE_SNAP,
+    ),
     ("empty_sql_with_snap", b"", b"{}"),
     ("empty_snap_with_sql", b"SELECT 1;", b""),
     (
@@ -64,9 +78,6 @@ VECTORS = [
     ("per_file_select1_with_empty_obj", b"SELECT 1;", b"{}"),
     ("per_file_empty_inputs", b"", b""),
     ("per_file_full_byte_range_sql", bytes(range(256)), b'{"v":"1"}'),
-    # Swap/framing vectors.
-    ("swap_a_sql_AAA_snap_BBB", b"AAA", b"BBB"),
-    ("swap_b_sql_BBB_snap_AAA", b"BBB", b"AAA"),
 ]
 
 

--- a/kit/filemigrate/testdata/digest_reference.py
+++ b/kit/filemigrate/testdata/digest_reference.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Reference implementation of the CombinedSHA256 artifact digest formula.
+
+Spec: docs/spec/file-migrations-api.md:365-371
+
+    SHA256(
+      "grizzle-artifact-v1" || 0x00 ||
+      "migration.sql" || 0x00 || uint64be(len(migration.sql)) || raw migration.sql bytes ||
+      "snapshot.json" || 0x00 || uint64be(len(snapshot.json)) || raw snapshot.json bytes
+    )
+
+This script exists so the golden hex values in artifact_digest_test.go can be
+regenerated independently of the Go production code. Run it after any
+deliberate, spec-amending change to the digest formula to recompute the
+goldens; do NOT regenerate goldens from the Go implementation — that defeats
+the cross-implementation pinning.
+
+Usage:
+    python3 kit/filemigrate/testdata/digest_reference.py
+
+Add a new vector by appending an entry to VECTORS below.
+"""
+
+import hashlib
+import struct
+
+
+def combined(sql: bytes, snap: bytes) -> str:
+    """Return the hex CombinedSHA256 per the spec formula."""
+    h = hashlib.sha256()
+    h.update(b"grizzle-artifact-v1")
+    h.update(b"\x00")
+    h.update(b"migration.sql")
+    h.update(b"\x00")
+    h.update(struct.pack(">Q", len(sql)))
+    h.update(sql)
+    h.update(b"snapshot.json")
+    h.update(b"\x00")
+    h.update(struct.pack(">Q", len(snap)))
+    h.update(snap)
+    return h.hexdigest()
+
+
+def per_file(content: bytes) -> str:
+    """Return the hex SHA-256 of a single file's raw bytes."""
+    return hashlib.sha256(content).hexdigest()
+
+
+# Test vectors pinned by artifact_digest_test.go.
+# Adding a new vector here? Also add the matching Go entry.
+VECTORS = [
+    ("both_empty", b"", b""),
+    ("small_ascii", b"CREATE TABLE t (id INT);", b'{"version":"1"}'),
+    ("empty_sql_with_snap", b"", b"{}"),
+    ("empty_snap_with_sql", b"SELECT 1;", b""),
+    (
+        "full_byte_range_with_zeros_and_high_bytes",
+        bytes(range(256)),
+        (b"\xff" * 100) + (b"\x00" * 50),
+    ),
+    ("zeros_1024_each", b"\x00" * 1024, b"\x00" * 1024),
+    # Per-file vectors (different snap shapes).
+    ("per_file_small_ascii", b"CREATE TABLE t (id INT);", b'{"version":"1"}'),
+    ("per_file_select1_with_empty_obj", b"SELECT 1;", b"{}"),
+    ("per_file_empty_inputs", b"", b""),
+    ("per_file_full_byte_range_sql", bytes(range(256)), b'{"v":"1"}'),
+    # Swap/framing vectors.
+    ("swap_a_sql_AAA_snap_BBB", b"AAA", b"BBB"),
+    ("swap_b_sql_BBB_snap_AAA", b"BBB", b"AAA"),
+]
+
+
+def main() -> None:
+    width = max(len(name) for name, _, _ in VECTORS) + 2
+    print(f"{'vector':<{width}} {'sql_sha256':<64}  {'snap_sha256':<64}  combined_sha256")
+    print("-" * (width + 1 + 64 + 2 + 64 + 2 + 64))
+    for name, sql, snap in VECTORS:
+        print(
+            f"{name:<{width}} "
+            f"{per_file(sql)}  "
+            f"{per_file(snap)}  "
+            f"{combined(sql, snap)}"
+        )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Closes #372.

Pins the byte-level combined artifact digest formula documented in `docs/spec/file-migrations-api.md`:

```text
SHA256(
  "grizzle-artifact-v1" || 0x00 ||
  "migration.sql" || 0x00 || uint64be(len(migration.sql)) || raw migration.sql bytes ||
  "snapshot.json" || 0x00 || uint64be(len(snapshot.json)) || raw snapshot.json bytes
)
```

The tests also pin the current per-file contract as SHA-256 of each file's exact raw bytes. Publishing the explicit normative per-file formulas and shared vectors remains tracked separately in #415.

The production implementation already matches these contracts. This PR is **tests-only** and adds layered conformance coverage so future drift is caught.

## What's covered

### Golden vectors

`TestArtifactDigest_CombinedGoldenVectors` and `TestArtifactDigest_PerFileGoldenVectors` use values produced independently by the Python reference implementation. Cases cover:

- empty payloads
- small ASCII SQL and JSON
- valid UTF-8 SQL and JSON containing Unicode, a SQL comment, CRLF line endings, and trailing newlines
- empty SQL with a non-empty snapshot and the inverse
- the full `0x00..0xFF` SQL byte range with NUL/`0xFF` snapshot content
- 1 KiB NUL payloads, exercising embedded NUL bytes and multi-byte big-endian lengths

### Byte-stream reassembly

`TestArtifactDigest_CombinedByteAssembly` independently rebuilds the specified byte stream with `bytes.Buffer` and `binary.BigEndian`, then verifies its SHA-256 against `CombinedSHA256`.

### Raw-byte normalization guards

`TestArtifactDigest_RawBytesAreNotNormalized` isolates and distinguishes:

- SQL LF versus CRLF
- JSON LF versus CRLF
- SQL comment present versus absent
- SQL trailing newline present versus absent
- JSON trailing newline present versus absent

For each pair, the affected per-file digest and the combined digest must differ.

### Other properties

- `TestArtifactDigest_CombinedSwapDistinguishable` verifies payload role/order sensitivity.
- `TestArtifactDigest_CombinedDeterministic` verifies artifact names do not affect the digest.
- `TestArtifactDigest_RoundtripsThroughRead` verifies digest consistency across in-memory create/read operations.

## Test plan

- [x] `python3 kit/filemigrate/testdata/digest_reference.py`
- [x] `go test -race -count=1 ./kit/filemigrate/ -run TestArtifactDigest -v`
- [x] `go vet ./...`
- [x] `go test -race -count=1 ./...`
- [x] `gofmt` and `git diff --check`

## Review

Focused local `work-issue` follow-up reviews completed:

- Lead architect: approved
- Senior software engineer: approved after unrelated Serena metadata was removed
- Technical writer: approved subject to the PR-description corrections applied here

## Notes

- Golden values are reproducible with `kit/filemigrate/testdata/digest_reference.py` and must not be regenerated from the Go production implementation.
- No production code changes.
