### PR TITLE
chore(repo): unify and refine backlog governance

### DIFF
--- a/.github/ISSUE_TEMPLATE/engineering_task.yml
+++ b/.github/ISSUE_TEMPLATE/engineering_task.yml
@@ -5,7 +5,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Use this form for a concrete engineering outcome. Maintainers will assign its workstream parent, milestone, and native dependency links during triage.
+        Use this form for a concrete engineering outcome. Maintainers assign a workstream parent and native dependency links during triage, and a milestone when the issue is scheduled.
 
   - type: textarea
     id: outcome

--- a/.github/ISSUE_TEMPLATE/engineering_task.yml
+++ b/.github/ISSUE_TEMPLATE/engineering_task.yml
@@ -1,0 +1,65 @@
+name: Engineering task
+description: Propose bounded implementation, refactoring, test, or repository work
+labels: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form for a concrete engineering outcome. Maintainers will assign its workstream parent, milestone, and native dependency links during triage.
+
+  - type: textarea
+    id: outcome
+    attributes:
+      label: Outcome
+      description: What observable result should this task produce?
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: Why is this needed, and which specification or existing behavior governs it?
+    validations:
+      required: true
+
+  - type: textarea
+    id: in-scope
+    attributes:
+      label: In scope
+      description: List the bounded responsibilities owned by this issue.
+    validations:
+      required: true
+
+  - type: textarea
+    id: out-of-scope
+    attributes:
+      label: Out of scope
+      description: List nearby work deliberately excluded from this issue.
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: Provide testable completion conditions.
+      placeholder: |
+        - [ ] ...
+        - [ ] ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: validation
+    attributes:
+      label: Validation plan
+      description: Identify the tests, checks, fixtures, or documentation needed to prove completion.
+    validations:
+      required: true
+
+  - type: textarea
+    id: references
+    attributes:
+      label: References
+      description: Link specifications, code, pull requests, or discussions. Do not maintain dependency lists here.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -18,8 +18,16 @@ body:
   - type: textarea
     id: proposal
     attributes:
-      label: Proposed solution
-      description: Describe the API or behaviour you have in mind. Code snippets welcome.
+      label: Desired outcome
+      description: Describe the observable result. API or behavior examples are welcome, but keep the outcome separate from a particular implementation.
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      description: What should be included, and what nearby work should explicitly remain out of scope?
     validations:
       required: true
 
@@ -30,6 +38,24 @@ body:
       description: Any other approaches you've thought about?
 
   - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: List observable, testable conditions that would make this request complete.
+      placeholder: |
+        - [ ] ...
+        - [ ] ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: compatibility
+    attributes:
+      label: Compatibility and migration impact
+      description: Note public API, dialect, data format, or upgrade implications.
+
+  - type: textarea
     id: context
     attributes:
-      label: Additional context
+      label: Specifications and additional context
+      description: Link relevant Grizzle specs, upstream behavior, examples, or prior discussions. Dependencies will be recorded with GitHub's native relationships during triage.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -24,10 +24,18 @@ body:
       required: true
 
   - type: textarea
-    id: scope
+    id: in-scope
     attributes:
-      label: Scope
-      description: What should be included, and what nearby work should explicitly remain out of scope?
+      label: In scope
+      description: What bounded behavior should this request include?
+    validations:
+      required: true
+
+  - type: textarea
+    id: out-of-scope
+    attributes:
+      label: Out of scope
+      description: What nearby behavior should this request explicitly exclude?
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/spec_change.yml
+++ b/.github/ISSUE_TEMPLATE/spec_change.yml
@@ -1,0 +1,58 @@
+name: Specification change
+description: Propose or ratify a product, API, format, or compatibility decision
+labels: [type:spec]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Implementation must not begin until required specification decisions are explicit and testable.
+
+  - type: textarea
+    id: decision
+    attributes:
+      label: Decision required
+      description: State the exact question this specification must answer.
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Context and constraints
+      description: Summarize current Grizzle behavior, normative specs, upstream RC.1 behavior, and hard constraints.
+    validations:
+      required: true
+
+  - type: textarea
+    id: options
+    attributes:
+      label: Options considered
+      description: Compare viable choices and their tradeoffs. Include a recommendation when possible.
+    validations:
+      required: true
+
+  - type: textarea
+    id: compatibility
+    attributes:
+      label: Compatibility impact
+      description: Cover public API, persisted formats, dialect support, generated code, and migration implications.
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Ratification criteria
+      description: List the decisions and specification updates required before implementation issues can become ready.
+      placeholder: |
+        - [ ] Normative behavior is documented.
+        - [ ] Unsupported behavior is explicit.
+        - [ ] Follow-up implementation issues are independently estimable.
+    validations:
+      required: true
+
+  - type: textarea
+    id: references
+    attributes:
+      label: References
+      description: Link the affected specs, upstream source, examples, or prior discussion. Native GitHub links will record implementation dependencies.

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -30,4 +30,4 @@ jobs:
           days-before-pr-stale: 60
           days-before-pr-close: 14
           stale-pr-label: stale
-          exempt-pr-labels: "status:in-progress,security"
+          exempt-pr-labels: "status:in-progress"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,7 +14,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10
+      - uses: actions/stale@1e223db275d687790206a7acac4d1a11bd6fe629 # v10
         with:
           stale-pr-message: >
             This pull request has been open for 60 days with no activity. It
@@ -23,8 +23,8 @@ jobs:
           close-pr-message: >
             Closing due to inactivity. Please reopen if you would like to
             continue with this pull request.
-          # Issues represent an intentionally ordered product backlog. They are
-          # closed only through explicit triage, never because they are quiet.
+          # Issues are closed through explicit triage; inactivity alone is not
+          # a closure criterion.
           days-before-issue-stale: -1
           days-before-issue-close: -1
           days-before-pr-stale: 60

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,32 +7,27 @@ on:
 
 jobs:
   stale:
-    name: Mark and close stale issues and PRs
+    name: Mark and close stale pull requests
     runs-on: ubuntu-latest
     permissions:
-      issues: write
+      issues: read
       pull-requests: write
 
     steps:
       - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10
         with:
-          stale-issue-message: >
-            This issue has been open for 60 days with no activity. It will be
-            closed in 14 days unless there is new activity or a maintainer
-            removes the `stale` label.
           stale-pr-message: >
             This pull request has been open for 60 days with no activity. It
             will be closed in 14 days unless there is new activity or a
             maintainer removes the `stale` label.
-          close-issue-message: >
-            Closing due to inactivity. If this is still relevant, please open
-            a new issue with updated context.
           close-pr-message: >
             Closing due to inactivity. Please reopen if you would like to
             continue with this pull request.
-          days-before-stale: 60
-          days-before-close: 14
-          stale-issue-label: stale
+          # Issues represent an intentionally ordered product backlog. They are
+          # closed only through explicit triage, never because they are quiet.
+          days-before-issue-stale: -1
+          days-before-issue-close: -1
+          days-before-pr-stale: 60
+          days-before-pr-close: 14
           stale-pr-label: stale
-          exempt-issue-labels: "pinned,security,in-progress"
-          exempt-pr-labels: "in-progress,security"
+          exempt-pr-labels: "status:in-progress,security"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ Open an issue using the **Bug report** template. Include:
 
 Open an issue using the **Feature request** template before writing code. This lets us discuss the design and avoid duplicated effort.
 
-Repository maintainers organize accepted work using the single-milestone model and native issue relationships described in the [project plan](docs/project-plan.md). Issue bodies should focus on outcome, scope, and testable acceptance criteria rather than duplicating dependency lists.
+Repository maintainers organize accepted work using a single scheduling model based on GitHub Milestones and the native issue relationships described in the [project plan](docs/project-plan.md). Issue bodies should focus on outcome, scope, and testable acceptance criteria rather than duplicating dependency lists.
 
 ## Development setup
 
@@ -27,7 +27,7 @@ go test ./...
 
 No external services are required for the unit tests. Integration tests (under `driver/pgx/`) require a PostgreSQL instance — set `GRIZZLE_TEST_DSN` to a connection string to run them.
 
-## Pull requests
+## Pull requests when contributions reopen
 
 1. **Fork** the repository and create a branch from `main`.
 2. Keep changes focused — one logical change per PR.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,8 @@ Open an issue using the **Bug report** template. Include:
 
 Open an issue using the **Feature request** template before writing code. This lets us discuss the design and avoid duplicated effort.
 
+Repository maintainers organize accepted work using the single-milestone model and native issue relationships described in the [project plan](docs/project-plan.md). Issue bodies should focus on outcome, scope, and testable acceptance criteria rather than duplicating dependency lists.
+
 ## Development setup
 
 ```sh

--- a/docs/project-handoff.md
+++ b/docs/project-handoff.md
@@ -1,5 +1,5 @@
 # Project Handoff (Retired)
 
-This document has been retired. The single source of truth for the Grizzle implementation roadmap and backlog state is now [project-plan.md](./project-plan.md), including its [current implementation frontier](./project-plan.md#current-implementation-frontier).
+This document has been retired. Start with [project-plan.md](./project-plan.md) for Grizzle's planning model and [current implementation frontier](./project-plan.md#current-implementation-frontier). The linked GitHub Milestones and native issue relationships are authoritative for live backlog, schedule, and dependency state.
 
 Historical migration-kit handoff context (PR `#272`, the `docs/file-migrations-spec` branch, the spec-first transition narrative) lives in the git log of `docs/` from before 2026-05-08.

--- a/docs/project-handoff.md
+++ b/docs/project-handoff.md
@@ -1,5 +1,5 @@
 # Project Handoff (Retired)
 
-This document has been retired. The single source of truth for the Grizzle implementation roadmap and backlog state is now [project-plan.md](./project-plan.md), including the live [Implementation Frontier](./project-plan.md#implementation-frontier) block at the top of that document.
+This document has been retired. The single source of truth for the Grizzle implementation roadmap and backlog state is now [project-plan.md](./project-plan.md), including its [current implementation frontier](./project-plan.md#current-implementation-frontier).
 
 Historical migration-kit handoff context (PR `#272`, the `docs/file-migrations-spec` branch, the spec-first transition narrative) lives in the git log of `docs/` from before 2026-05-08.

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -1,201 +1,159 @@
 # Grizzle Project Plan
 
-Single source of truth for the Grizzle implementation roadmap and backlog state. The specs in `docs/spec/` are normative for *behavior*; this document is normative for *sequencing* and *backlog hygiene*.
+This document defines how Grizzle's roadmap is organized and how work moves from an idea to implementation. Specifications under [`docs/spec/`](./spec/) remain authoritative for behavior.
 
-_Last refreshed: 2026-05-08._
+_Last reviewed: 2026-07-17._
 
-## Contents
+## Planning model
 
-- [Implementation Frontier](#implementation-frontier)
-- [Source Of Truth](#source-of-truth)
-- [Roadmap](#roadmap)
-  - [Workstreams](#workstreams)
-  - [Recommended Order](#recommended-order)
-  - [Slice Plan](#slice-plan)
-  - [Parallel Work Guidance](#parallel-work-guidance)
-- [Code Triage](#code-triage)
-  - [Package-Level Classification](#package-level-classification)
-  - [Quarantine And Delete/Replace](#quarantine-and-deletereplace)
-- [Label Scheme](#label-scheme)
-- [Backlog Hygiene Checklist](#backlog-hygiene-checklist)
+Grizzle uses **one scheduling axis: GitHub Milestones**.
 
-## Implementation Frontier
+- A milestone answers **when and in what sequence** an issue is intended to ship.
+- Native parent/sub-issue relationships answer **which outcome or workstream owns** the issue.
+- Native blocked-by/blocking relationships record **hard execution dependencies**.
+- Labels answer **what kind of work it is and its current lifecycle state**.
 
-| Item | Status |
-| --- | --- |
-| Last completed | **[Slice 0](https://github.com/sofired/grizzle/milestone/7)** (closed). `kit/filemigrate/` package + diagnostics + resource limits + source/artifact/managed test stores landed in PR #303. |
-| Active | **[Slice 1](https://github.com/sofired/grizzle/milestone/8)** — artifact discovery and offline validation core. Slice-tagged hardening from Slice 0 dev (TOCTOU, naming validation, race hardening) folds into this milestone. |
-| Next | **[Slice 2](https://github.com/sofired/grizzle/milestone/9)** — snapshot and schema input planning. |
-| Parallel-safe workstreams | Schema (#282), Query (#283), Codegen (#284), Driver (#285), Dialect (#286), Pull (#288), Docs (#289). See [Parallel Work Guidance](#parallel-work-guidance). |
-| Blocked-by-spec | Direct-sync `push` (#157, #296). Sequence support (#137, #248, #250). Generated columns (#172, #253, #254). Non-transactional DDL header (#277). Hash-drift detection (#278). Non-interactive rename answers (#279). View dependency ordering (#240). |
+Workstream epics are navigation indexes, not a second roadmap. The retired `slice:*` labels and release/capability milestone axis must not be recreated. An issue body should explain the outcome, scope, and acceptance criteria; it should not duplicate dependency lists or milestone rollups.
 
-The full slice-by-slice picture is in [Slice Plan](#slice-plan).
+## Source of truth
 
-## Source Of Truth
+Use this precedence for product and implementation decisions:
 
-Use this hierarchy for all classification and implementation decisions:
+1. Grizzle specifications under `docs/spec/`.
+2. Tagged Drizzle ORM / Drizzle Kit `v1.0.0-rc.1` source for upstream behavior.
+3. Drizzle documentation for the matching release line.
+4. Current repository code as implementation evidence, not the target contract.
+5. Open GitHub issues as planning records.
 
-1. Grizzle specs under `docs/spec/`
-2. tagged Drizzle ORM / Drizzle Kit `v1.0.0-rc.1` (referred to as RC.1 throughout this document) source for upstream behavior
-3. Drizzle docs for the matching release line
-4. current repository code only as implementation evidence, never as the target contract
-5. open GitHub issues as planning records only
+If an issue conflicts with a specification, rewrite or supersede the issue before implementation. If code conflicts with a specification, treat the code as implementation debt unless the specification is deliberately amended.
 
-If current code and specs disagree, the code is implementation debt unless the spec is amended. If the specs and tagged Drizzle RC.1 source disagree, the specs must explicitly document the Grizzle decision. If issues conflict with specs, the issue is stale and must be rewritten or superseded.
+## Milestones
 
-Background specs not directly cited below but worth reading when classifying migration-kit code or issues: [`file-migrations-workflow.md`](./spec/file-migrations-workflow.md) for the end-to-end workflow narrative, and [`file-migrations-upstream-mapping.md`](./spec/file-migrations-upstream-mapping.md) for RC.1 → Grizzle behavior mapping.
+Each open delivery issue has at most one milestone. Milestone numbers are ordered and stable; names describe outcomes rather than internal planning jargon.
 
-## Roadmap
-
-### Workstreams
-
-| Workstream | Parent issue | Source specs | Posture |
-| --- | --- | --- | --- |
-| Schema DSL and type system | [#282](https://github.com/sofired/grizzle/issues/282) | `schema.md`, `types.md`, `dialects.md` | Partial implementation with known parity gaps. |
-| Query builder and relations | [#283](https://github.com/sofired/grizzle/issues/283) | `query-builder.md`, `relations.md`, `dialects.md` | Substantial implementation with remaining gaps and dialect-gating bugs. |
-| Codegen | [#284](https://github.com/sofired/grizzle/issues/284) | `codegen.md`, `types.md` | Implemented but narrower than target; Slice 0 PR aligned `numeric` mapping. |
-| Drivers, transactions, prepared statements | [#285](https://github.com/sofired/grizzle/issues/285) | `transactions.md`, `query-builder.md` | Partial; pgx stronger than database/sql. |
-| Dialects | [#286](https://github.com/sofired/grizzle/issues/286) | `dialects.md` | Useful current matrix; some spec/interface drift. |
-| Migration kit / file migrations | [#287](https://github.com/sofired/grizzle/issues/287) | `kit.md`, `file-migrations-*.md` | Slice 0 complete; Slice 1 next. Legacy `kit/migrate*.go`, `kit/apply.go`, `kit/snapshot.go` quarantined pending Slice 8 cleanup. |
-| Pull / introspection | [#288](https://github.com/sofired/grizzle/issues/288) | `pull.md`, `file-migrations-snapshot-fields.md`, `schema.md`, `codegen.md` | Live introspection in `kit/introspect/`; `pull` workflow absent. |
-| Docs/release/policy | [#289](https://github.com/sofired/grizzle/issues/289) | `README.md`, `docs/spec/README.md`, `overview.md` | Pre-release posture; refresh this doc whenever frontier changes. |
-
-### Recommended Order
-
-This order is about dependency safety, not exclusivity. Independent query/schema/driver fixes proceed when they are spec-aligned and do not conflict with the migration-kit sequence.
-
-1. Build file-migration slices 0-8 in order (see [Slice Plan](#slice-plan)).
-2. Continue non-blocking workstream parity work in parallel when scoped per [Parallel Work Guidance](#parallel-work-guidance).
-3. Pause new file-migration implementation if [Backlog Hygiene Checklist](#backlog-hygiene-checklist) items regress.
-
-### Slice Plan
-
-Each slice has its own GitHub Milestone. Live child-issue tracking, open/closed counts, and progress live there. The slice parent issues that previously served this role were retired on 2026-05-08 with redirect comments.
-
-The Grizzle repo uses **two milestone axes**:
-
-- **Slice milestones** (this section) — implementation sequence for the file-migration workflow, one per slice 0-8. Granular, ordered, time-bounded.
-- **Release/capability milestones** (`M1: Clean house`, `M4: Query builder parity`, `M5: Schema DSL + codegen completeness`, `M6: Advanced features`) — what ships when, across all workstreams. `M2: Dialect foundation` and `M3: Kit workflow` are now closed; M3's scope was absorbed into the slice milestones.
-
-Both axes are GitHub Milestones, and a GitHub issue can only carry **one milestone**, so the axes are mutually exclusive per issue. Assignment rule: if the issue is part of a file-migration slice, it goes on the slice milestone (the slice progress rollup depends on this being complete); otherwise it goes on the relevant M-milestone. Cross-axis association (e.g., a Slice 3 issue that also serves M5 capability completeness) is captured in the issue body, not by a second milestone.
-
-| Slice | Status | Milestone | Spec | Code involvement |
-| --- | --- | --- | --- | --- |
-| Slice 0: package boundary and test harness | Done (PR #303) | [Slice 0](https://github.com/sofired/grizzle/milestone/7) (closed) | `file-migrations-implementation-sequence.md` §Slice 0 | `kit/filemigrate/` (new). |
-| Slice 1: artifact discovery and offline validation | Active | [Slice 1](https://github.com/sofired/grizzle/milestone/8) | `file-migrations-implementation-sequence.md` §Slice 1 | Build artifact loader/validator; do not reuse `kit.LoadJSON`. |
-| Slice 2: snapshot and schema input planning | Upcoming | [Slice 2](https://github.com/sofired/grizzle/milestone/9) | `file-migrations-implementation-sequence.md` §Slice 2 | Adapt `schema/*`, `gen/parser/*`, `kit/snapshot.go` concepts into RC.1 snapshot planning. |
-| Slice 3: `check` | Upcoming | [Slice 3](https://github.com/sofired/grizzle/milestone/10) | `file-migrations-check.md` | Adapt `kit/diff.go` graph/diff logic. |
-| Slice 4: `generate` | Upcoming | [Slice 4](https://github.com/sofired/grizzle/milestone/11) | `file-migrations-generate.md`, `file-migrations-artifacts.md` | `kit/diff.go`, `kit/sqlgen*.go`, `schema/*`, `gen/parser`. |
-| Slice 5: history, locking, sessions | Upcoming (no child issues yet) | [Slice 5](https://github.com/sofired/grizzle/milestone/12) | `file-migrations-history.md`, `file-migrations-execution.md` | New session/history/locking under `kit/filemigrate`; `driver/*`, `dialect/`. |
-| Slice 6: `migrate` | Upcoming | [Slice 6](https://github.com/sofired/grizzle/milestone/13) | `file-migrations-execution.md` | Implement artifact execution; quarantine `kit/migrate*.go`. |
-| Slice 7: `pull` and `pull --init` | Upcoming | [Slice 7](https://github.com/sofired/grizzle/milestone/14) | `pull.md` | Adapt `kit/introspect/`, `schema/*`, `gen/codegen`. |
-| Slice 8: CLI cutover and cleanup | Upcoming | [Slice 8](https://github.com/sofired/grizzle/milestone/15) | `file-migrations-api.md`, `kit.md` | Rewire `cmd/grizzle/main.go`; remove legacy `kit/migrate*.go`, `kit/apply.go`, snapshot/diff CLI commands. |
-
-Code-area follow-up tracking issues hang off the milestones above:
-
-- [#296](https://github.com/sofired/grizzle/issues/296) — Quarantine direct-sync push helpers (blocked-by-spec)
-- [#297](https://github.com/sofired/grizzle/issues/297) — Quarantine legacy live-diff migrate/status helpers (slice:8)
-- [#298](https://github.com/sofired/grizzle/issues/298) — Replace legacy snapshot file model (slice:2)
-- [#299](https://github.com/sofired/grizzle/issues/299) — Adapt schema definitions and static loader for strict file migrations (slice:2)
-- [#300](https://github.com/sofired/grizzle/issues/300) — Adapt diff and SQL rendering to RC.1 DDL entities (slice:4)
-- [#301](https://github.com/sofired/grizzle/issues/301) — Adapt introspection for `pull` and `pull --init` (slice:7)
-
-The Slice 5 milestone has no child issues yet; the closed umbrella (#293) was the only assigned issue, so the GitHub progress rollup currently shows 100% but reflects no real work. Treat the milestone as a placeholder for now: child work items (history table creation/validation, DB-backed locking, migration session interfaces, dialect capability checks) are authored as Slice 5 starts. Until then, rely on `file-migrations-history.md` and the Slice 5 spec section, not the milestone rollup, for Slice 5 status.
-
-### Parallel Work Guidance
-
-Safe to work in parallel with file-migration slices when scoped and spec-backed:
-
-- Query-builder bug fixes and missing operators (under #283).
-- Codegen type-mapping fixes (under #284); the Slice 0 PR aligned `numeric` and noted the `int`/`int32` deviation.
-- Schema-builder parity fixes (under #282).
-- Dialect doc/interface synchronization (under #286).
-- Driver tests and transaction-wrapper work (under #285).
-
-Do **not** work in parallel if it changes:
-
-- public migration command meanings,
-- `kit.Snapshot`/artifact semantics,
-- history-table semantics,
-- schema input accepted by file migrations, or
-- generated source format consumed by `pull` or file migrations,
-
-unless explicitly coordinated with the relevant slice.
-
-## Code Triage
-
-The classifications below describe the disposition of *existing* code under spec precedence. They are not behavioral contracts — specs (per [Source Of Truth](#source-of-truth)) remain authoritative even when a path is classified Keep.
-
-### Package-Level Classification
-
-| Path | Project area | Classification | Why |
-| --- | --- | --- | --- |
-| `cmd/grizzle` | CLI | Adapt / Quarantine | Six current commands (`snapshot`, `diff`, `migrate`, `status`, `gen`, `sql`); `gen` and `sql` keep, the rest are quarantined for Slice 8 cutover. |
-| `dialect/` | Dialect feature matrix | Adapt | Useful matrix; needs fail-fast capability gating and Slice 5 migration-session hooks. |
-| `driver/pgx/` | PostgreSQL driver | Adapt | Useful driver; prepared-statement and transaction gaps remain. |
-| `driver/sql/` | database/sql driver | Adapt | Useful generic driver for MySQL/SQLite. |
-| `expr/` | SQL expression builders | Keep (file-migration scope) / Adapt (project-wide) | Useful for query expressions; do not treat as the file-migration DDL-expression model. |
-| `gen/codegen/` | typed codegen | Adapt | Slice 0 PR fixed `numeric` mapping; remaining type-mapping decisions tracked under #284. |
-| `gen/parser/` | static schema parser | Adapt / replace | Adapted into the file-migration schema loader during Slice 2 (#299). |
-| `internal/testschema/` | fixtures | Keep / Adapt | Useful fixtures; reuse only where they match strict file-migration schema input. |
-| `kit/` | migration kit (legacy + new) | Split: Adapt / Quarantine / Delete-replace | Split: `diff.go`, `sqlgen*.go`, `introspect/` adapt; `apply.go`, `migrate*.go`, `snapshot.go` quarantine; legacy `kit.Snapshot` shape and `_grizzle_migrations` history are Delete/Replace. |
-| `kit/filemigrate/` | RC.1 file-migration core | **Keep** (target) | Slice 0 deliverable. Stores, diagnostics, resource limits, error codes. Slices 1-8 build inside this package. |
-| `kit/introspect/` | live DB introspection | Adapt | Foundation for Slice 7 `pull` adapters. |
-| `query/` | query builder | Keep (file-migration scope) / Adapt (project-wide) | Substantial; remaining gaps tracked under #283. |
-| `schema/pg/`, `schema/mysql/`, `schema/sqlite/` | schema DSL | Adapt | Useful builders; Slice 2 hardens for strict RC.1 input. |
-
-### Quarantine And Delete/Replace
-
-These are forward-looking targets for Slice 6 and Slice 8 cleanup. The work is tracked on the slice parents and code follow-up issues; the table is reference, not action.
-
-| Item | Current behavior | Target replacement | Slice |
-| --- | --- | --- | --- |
-| `kit/apply.go` (`Push`, `DryRun`) | Direct-sync push against a live DB. | No public target until a push spec exists ([#296](https://github.com/sofired/grizzle/issues/296)). | Deferred (blocked-by-spec) |
-| `kit/migrate.go`, `kit/migrate_mysql.go`, `kit/migrate_sqlite.go` | Live-diff migrate/status; reads `_grizzle_migrations`. | Artifact-based `migrate` from `kit/filemigrate`; history table `__grizzle_migrations` (PG schema `grizzle`); pending detection by name; SHA-256 over raw bytes. | Slice 6 / Slice 8 ([#297](https://github.com/sofired/grizzle/issues/297)) |
-| `cmd/grizzle` legacy commands | Public `snapshot`, `diff`, legacy `migrate`, `status`. | Target CLI: `generate`, `check`, `migrate`, `push`, `pull`, `introspect`. | Slice 8 |
-| `kit/snapshot.go` (`kit.Snapshot`, `SaveJSON`, `LoadJSON`, `FromDefs`, `FromSchema`, `SchemaObjects`) | Legacy snapshot envelope (`tables`/`views`/`enums`). | RC.1 snapshot envelope under `kit/filemigrate` (`version`, `dialect`, `id`, `prevIds`, `ddl`, `renames`). Useful concepts may be adapted, but the legacy shape must not define the artifact format. | Slice 2 / Slice 8 ([#298](https://github.com/sofired/grizzle/issues/298)) |
-| `_grizzle_migrations` history table; `checksum`, `sql_batch`, `description` columns; `ChecksumSQL` | Legacy live-diff history. | Target `__grizzle_migrations` with `id`, `hash`, `created_at`, `name`, `applied_at`. SHA-256 over raw `migration.sql` bytes. | Slice 5 / Slice 6 |
-
-## Label Scheme
-
-GitHub labels with project-defined semantics:
-
-| Family | Members | Semantics |
+| Order | Milestone | Outcome |
 | --- | --- | --- |
-| `area:*` | `area:schema`, `area:query`, `area:codegen`, `area:driver`, `area:dialect`, `area:kit`, `area:file-migrations`, `area:pull`, `area:docs` | Primary code area the issue affects. One per issue, with the explicit exception that `area:kit` and `area:file-migrations` may co-occur per the `area:kit` vs `area:file-migrations` row below. `area:docs` covers documentation, repo hygiene, CI, and release policy. |
-| `slice:*` | `slice:0` through `slice:8` | **Issue is delivered as part of Slice N** — authored, reviewed, merged within that slice's PR. **One slice tag per issue.** Cross-slice dependencies belong in the issue body, not as additional slice tags. Each `slice:N` label has a corresponding [GitHub Milestone](https://github.com/sofired/grizzle/milestones); the milestone is the live tracker (open/closed counts, progress), the label is the searchable filter. |
-| `priority:*` | `priority:critical`, `priority:high`, `priority:medium`, `priority:low` | Scheduling priority. (Renamed from `P0`-`P3` on 2026-05-08.) |
-| `phase:implementation` | — | Implementation work (code/tests). Spec-only work uses `blocked-by-spec` instead. |
-| `blocked-by-spec` | — | No implementation until a spec is written or amended. |
-| `superseded` | — | Old direction; replaced by another issue or closed. |
-| `enhancement-candidate` | — | Out of scope for the current phase; reconsider in next planning cycle. |
-| `area:kit` vs `area:file-migrations` | — | `area:kit` is shared migration-kit infrastructure (diff, SQL rendering, introspection adapters). `area:file-migrations` is the RC.1 folder-per-migration workflow specifically. An issue may carry both when the line is unclear. |
-| GitHub defaults | `bug`, `enhancement`, `testing`, `documentation`, `good first issue`, `help wanted`, `in-progress`, `ready-for-merge`, `dependencies`, `github_actions`, `go`, `invalid`, `wontfix`, `duplicate`, `question`, `needs-triage` | No project-defined semantics; standard GitHub usage. The project-defined scheme is the rows above. |
+| 00 | File-migration foundation (complete) | Package boundary, diagnostics, limits, and test stores. |
+| 01 | Backlog and API governance | Stable public API policy, correctness cleanup, and repository governance. |
+| 02 | Artifact discovery and validation | Safely discover, load, hash, and validate raw artifacts. |
+| 03 | Snapshot and schema planning | Typed snapshot entities, static schema input, metadata, and comparison inputs. |
+| 04 | Check | Reusable offline check API and command handler. |
+| 05 | Generate | Plan DDL changes and publish complete artifacts atomically. |
+| 06 | Migration sessions and history | Session, capability, history, credential, and lock foundations. |
+| 07 | Migrate | Execute validated artifacts and record deterministic history. |
+| 08 | Pull and pull --init | Introspect, bootstrap, render, and publish managed sources safely. |
+| 09 | CLI cutover and release | Register the unified CLI, remove legacy paths, and publish cutover guidance. |
 
-**Combination rule:** `blocked-by-spec` and `slice:N` may coexist on a single issue; the combination means "tentatively planned for Slice N, but no implementation until the relevant spec is written or amended." Examples: #277 (Slice 6, awaiting non-transactional DDL spec amendment).
+Milestone progress is the authoritative delivery rollup. Do not put future enhancement candidates into a milestone merely to categorize them; keep them in the icebox until a planning review promotes them.
 
-## Backlog Hygiene Checklist
+## Workstream indexes
 
-Apply this checklist when promoting between slices or reviewing backlog drift. Each item is mechanically checkable.
+Every issue is attached to one native parent. Cross-cutting concerns use labels and native dependencies rather than multiple parent checklists.
 
-Code-side gate (from [Code Triage](#code-triage)):
+| Workstream | Parent issue | Primary specifications |
+| --- | --- | --- |
+| Schema DSL and type system | [#282](https://github.com/sofired/grizzle/issues/282) | `schema.md`, `types.md`, `dialects.md` |
+| Query builder and relations | [#283](https://github.com/sofired/grizzle/issues/283) | `query-builder.md`, `relations.md`, `dialects.md` |
+| Code generation and metadata | [#284](https://github.com/sofired/grizzle/issues/284) | `codegen.md`, `types.md` |
+| Drivers and transactions | [#285](https://github.com/sofired/grizzle/issues/285) | `transactions.md`, `query-builder.md` |
+| Dialect capabilities | [#286](https://github.com/sofired/grizzle/issues/286) | `dialects.md` |
+| File migrations | [#287](https://github.com/sofired/grizzle/issues/287) | `file-migrations-*.md`, `kit.md` |
+| Pull and introspection | [#288](https://github.com/sofired/grizzle/issues/288) | `pull.md`, `schema.md`, `codegen.md` |
+| Documentation and policy | [#289](https://github.com/sofired/grizzle/issues/289) | `README.md`, `docs/spec/README.md`, `overview.md` |
 
-- [x] Every migration-related code path has an initial classification in [Package-Level Classification](#package-level-classification).
-- [x] Old live-diff/checksum/snapshot behavior is identified as Quarantine or Delete/Replace.
-- [x] `kit/filemigrate` exists with diagnostics, resource limits, and source/artifact/managed test stores (Slice 0 complete).
-- [ ] The six remaining open code-area follow-up issues (#296-#301) close as their slice ships.
+Smaller delivery epics may sit below a workstream parent when an outcome has multiple independently workable tasks. They do not replace milestones.
 
-Issue-side gate:
+## Current implementation frontier
 
-- [x] Old-direction issues are closed or marked `superseded` (#154, #249, #273-#275, #280).
-- [x] Defer targets carry `blocked-by-spec` (#157, #296, #137, #248, #250, #172, #253, #254, #277, #278, #279, #240).
-- [x] One milestone exists for every Slice 0-8 (milestones 7-15).
-- [x] One workstream parent exists for every project-wide area (#282-#289).
-- [x] Every open issue carries an `area:*` label.
-- [x] Every implementation issue with a target slice carries exactly one `slice:N` tag (the delivery slice).
-- [x] Direct-sync `push` and unsupported object-family work remain `blocked-by-spec` until spec exists.
+Milestone 02 is the active file-migration frontier.
 
-Spec-side gate:
+Recommended queue:
 
-- [x] Specs are updated before implementation for any `blocked-by-spec` work (none satisfied yet).
-- [ ] If the [Workstreams](#workstreams) table cites a planned behavior that is not specified, the relevant spec is amended before coding starts.
+1. Complete the raw-byte digest work in [#372](https://github.com/sofired/grizzle/issues/372).
+2. Complete filesystem safety [#304](https://github.com/sofired/grizzle/issues/304), then resolver validation [#316](https://github.com/sofired/grizzle/issues/316), then artifact-directory validation [#310](https://github.com/sofired/grizzle/issues/310).
+3. Ratify the durable result contract in [#321](https://github.com/sofired/grizzle/issues/321) and SQL byte validation in [#374](https://github.com/sofired/grizzle/issues/374).
+4. Implement the loader in [#319](https://github.com/sofired/grizzle/issues/319).
+5. Complete malformed-layout and snapshot-envelope rejection in [#320](https://github.com/sofired/grizzle/issues/320).
+6. Keep publication-race hardening [#308](https://github.com/sofired/grizzle/issues/308) ready for the first writer that needs it.
+
+GitHub's native dependency view is authoritative if this list and issue state ever diverge.
+
+Milestone 03 begins with the shared metadata contract [#434](https://github.com/sofired/grizzle/issues/434). Typed DDL, snapshot parsing, static source loading, and downstream code-generation work remain blocked until their native prerequisites are complete.
+
+## Product decisions
+
+- Direct-sync `push` remains specification-first. Implementation issue [#157](https://github.com/sofired/grizzle/issues/157) must not proceed until [#402](https://github.com/sofired/grizzle/issues/402) is ratified.
+- Public API naming and stability are governed by [#74](https://github.com/sofired/grizzle/issues/74).
+- Custom migration SQL is opaque: it is not parsed or executed to infer a snapshot. Its DDL state remains the effective parent snapshot.
+- The CLI cutover removes the legacy `sql` command. A future read-only schema-rendering command requires a separate proposal.
+- Unsupported dialect behavior fails before execution; builders must not silently remove clauses or substitute false/NULL expressions.
+
+## Issue standard
+
+### Titles
+
+Use a concise conventional form:
+
+```text
+type(area): outcome
+```
+
+Common types are `feat`, `fix`, `test`, `docs`, `spec`, `refactor`, `chore`, and `epic`.
+
+### Bodies
+
+An implementation issue should normally contain:
+
+1. **Outcome** — the observable result.
+2. **Context** — why the work exists and the relevant specification.
+3. **In scope** — bounded responsibilities.
+4. **Out of scope** — nearby work deliberately excluded.
+5. **Acceptance criteria** — testable completion conditions.
+
+Specification issues should replace implementation scope with the decisions that must be ratified. Epics should state the outcome and definition of done; their native sub-issue list provides the rollup.
+
+Do not maintain `Depends on`, `Blocked by`, workstream-parent, milestone, or delivery checklists in issue bodies. Use GitHub's native relationships and Milestone field.
+
+### Labels
+
+| Family | Meaning |
+| --- | --- |
+| `area:*` | Affected product/code area. Use one primary area; add a supporting area only when the issue genuinely crosses a package boundary. |
+| `priority:*` | Product urgency: critical, high, medium, or low. |
+| `status:ready` | Fully specified, unblocked, and suitable to start now. |
+| `status:in-progress` | Active implementation or an active pull request exists. |
+| `status:blocked` | Promoted work with an unresolved hard dependency or required decision. |
+| `status:icebox` | Valid future work not currently scheduled. |
+| `type:epic` | Navigational outcome with native sub-issues. |
+| `type:spec` | A decision/specification record, not implementation. |
+| `blocked-by-spec` | An implementation issue that cannot begin until a separate specification issue is ratified. |
+| `superseded` | Closed record retained for history after consolidation. |
+| `enhancement-candidate` | Optional capability awaiting a future planning review. |
+
+Apply no more than one `status:*` label. Native dependency state is authoritative; the status label makes the current execution view easy to scan.
+
+## Workflow
+
+1. Triage a new report into the appropriate workstream parent.
+2. Reconcile the request with the normative specification.
+3. Split work until each implementation issue has one testable outcome.
+4. Record hard prerequisites with native blocked-by links.
+5. Assign the earliest milestone in which the outcome is actually required.
+6. Apply `status:ready` only when all prerequisites and decisions are resolved.
+7. Move to `status:in-progress` when work starts; close through the implementing pull request.
+8. Review blocked and icebox work during milestone planning rather than through automated inactivity closure.
+
+Issue stale-closing is disabled. Planned work should be closed only by an explicit product decision, completion, duplication, or supersession. Pull requests may still be marked stale so abandoned implementation branches remain visible.
+
+## Review checklist
+
+At milestone boundaries, verify:
+
+- [ ] Open milestone issues have a single clear outcome and testable acceptance criteria.
+- [ ] Every open issue has one native parent.
+- [ ] Hard prerequisites use native dependencies and are absent from the body.
+- [ ] Exactly one scheduling model—the Milestone field—is in use.
+- [ ] No issue has more than one `status:*` label.
+- [ ] Completed, duplicate, and obsolete work is explicitly closed with a redirect comment.
+- [ ] Specifications are ratified before implementation issues carrying `blocked-by-spec` become ready.
+- [ ] The active queue matches GitHub's dependency state.

--- a/docs/project-plan.md
+++ b/docs/project-plan.md
@@ -2,7 +2,7 @@
 
 This document defines how Grizzle's roadmap is organized and how work moves from an idea to implementation. Specifications under [`docs/spec/`](./spec/) remain authoritative for behavior.
 
-_Last reviewed: 2026-07-17._
+_Last reviewed: 2026-07-18._
 
 ## Planning model
 
@@ -29,26 +29,26 @@ If an issue conflicts with a specification, rewrite or supersede the issue befor
 
 ## Milestones
 
-Each open delivery issue has at most one milestone. Milestone numbers are ordered and stable; names describe outcomes rather than internal planning jargon.
+Each open delivery issue has at most one milestone. Numeric title prefixes are ordered and stable; GitHub's internal milestone IDs are not part of the planning contract.
 
 | Order | Milestone | Outcome |
 | --- | --- | --- |
-| 00 | File-migration foundation (complete) | Package boundary, diagnostics, limits, and test stores. |
-| 01 | Backlog and API governance | Stable public API policy, correctness cleanup, and repository governance. |
-| 02 | Artifact discovery and validation | Safely discover, load, hash, and validate raw artifacts. |
-| 03 | Snapshot and schema planning | Typed snapshot entities, static schema input, metadata, and comparison inputs. |
-| 04 | Check | Reusable offline check API and command handler. |
-| 05 | Generate | Plan DDL changes and publish complete artifacts atomically. |
-| 06 | Migration sessions and history | Session, capability, history, credential, and lock foundations. |
-| 07 | Migrate | Execute validated artifacts and record deterministic history. |
-| 08 | Pull and pull --init | Introspect, bootstrap, render, and publish managed sources safely. |
-| 09 | CLI cutover and release | Register the unified CLI, remove legacy paths, and publish cutover guidance. |
+| 00 | [File-migration foundation (complete)](https://github.com/sofired/grizzle/milestone/7) | Package boundary, diagnostics, limits, and test stores. |
+| 01 | [Backlog and API governance](https://github.com/sofired/grizzle/milestone/1) | Stable public API policy, correctness cleanup, and repository governance. |
+| 02 | [Artifact discovery and validation](https://github.com/sofired/grizzle/milestone/8) | Safely discover, load, hash, and validate raw artifacts. |
+| 03 | [Snapshot and schema planning](https://github.com/sofired/grizzle/milestone/9) | Typed snapshot entities, static schema input, metadata, and comparison inputs. |
+| 04 | [Check](https://github.com/sofired/grizzle/milestone/10) | Reusable offline check API and command handler. |
+| 05 | [Generate](https://github.com/sofired/grizzle/milestone/11) | Plan DDL changes and publish complete artifacts atomically. |
+| 06 | [Migration sessions and history](https://github.com/sofired/grizzle/milestone/12) | Session, capability, history, credential, and lock foundations. |
+| 07 | [Migrate](https://github.com/sofired/grizzle/milestone/13) | Execute validated artifacts and record deterministic history. |
+| 08 | [Pull and pull --init](https://github.com/sofired/grizzle/milestone/14) | Introspect, bootstrap, render, and publish managed sources safely. |
+| 09 | [CLI cutover and release](https://github.com/sofired/grizzle/milestone/15) | Register the unified CLI, remove legacy paths, and publish cutover guidance. |
 
 Milestone progress is the authoritative delivery rollup. Do not put future enhancement candidates into a milestone merely to categorize them; keep them in the icebox until a planning review promotes them.
 
 ## Workstream indexes
 
-Every issue is attached to one native parent. Cross-cutting concerns use labels and native dependencies rather than multiple parent checklists.
+Every non-root issue has exactly one native parent. Issues #282–#289 are the intentional root workstream indexes. Cross-cutting concerns use labels and native dependencies rather than multiple parent checklists.
 
 | Workstream | Parent issue | Primary specifications |
 | --- | --- | --- |
@@ -65,20 +65,9 @@ Smaller delivery epics may sit below a workstream parent when an outcome has mul
 
 ## Current implementation frontier
 
-Milestone 02 is the active file-migration frontier.
+Milestone 01 is the active governance queue and Milestone 02 is the active file-migration delivery frontier. Use the linked milestone pages together with `status:ready` and `status:in-progress` filters for the live queue. GitHub's native dependency view is authoritative; this document intentionally does not duplicate a manually maintained issue order.
 
-Recommended queue:
-
-1. Complete the raw-byte digest work in [#372](https://github.com/sofired/grizzle/issues/372).
-2. Complete filesystem safety [#304](https://github.com/sofired/grizzle/issues/304), then resolver validation [#316](https://github.com/sofired/grizzle/issues/316), then artifact-directory validation [#310](https://github.com/sofired/grizzle/issues/310).
-3. Ratify the durable result contract in [#321](https://github.com/sofired/grizzle/issues/321) and SQL byte validation in [#374](https://github.com/sofired/grizzle/issues/374).
-4. Implement the loader in [#319](https://github.com/sofired/grizzle/issues/319).
-5. Complete malformed-layout and snapshot-envelope rejection in [#320](https://github.com/sofired/grizzle/issues/320).
-6. Keep publication-race hardening [#308](https://github.com/sofired/grizzle/issues/308) ready for the first writer that needs it.
-
-GitHub's native dependency view is authoritative if this list and issue state ever diverge.
-
-Milestone 03 begins with the shared metadata contract [#434](https://github.com/sofired/grizzle/issues/434). Typed DDL, snapshot parsing, static source loading, and downstream code-generation work remain blocked until their native prerequisites are complete.
+Milestone 03 begins after its public API and shared metadata prerequisites are resolved. Typed DDL, snapshot parsing, static source loading, and downstream code-generation work remain governed by their native prerequisites.
 
 ## Product decisions
 
@@ -122,15 +111,13 @@ Do not maintain `Depends on`, `Blocked by`, workstream-parent, milestone, or del
 | `priority:*` | Product urgency: critical, high, medium, or low. |
 | `status:ready` | Fully specified, unblocked, and suitable to start now. |
 | `status:in-progress` | Active implementation or an active pull request exists. |
-| `status:blocked` | Promoted work with an unresolved hard dependency or required decision. |
 | `status:icebox` | Valid future work not currently scheduled. |
 | `type:epic` | Navigational outcome with native sub-issues. |
 | `type:spec` | A decision/specification record, not implementation. |
-| `blocked-by-spec` | An implementation issue that cannot begin until a separate specification issue is ratified. |
 | `superseded` | Closed record retained for history after consolidation. |
 | `enhancement-candidate` | Optional capability awaiting a future planning review. |
 
-Apply no more than one `status:*` label. Native dependency state is authoritative; the status label makes the current execution view easy to scan.
+Apply no more than one `status:*` label. Native dependency state is the only blocked-state authority. A milestone-assigned issue with no status is scheduled but not promoted into the active queue; root workstream epics also carry no execution status.
 
 ## Workflow
 
@@ -141,7 +128,7 @@ Apply no more than one `status:*` label. Native dependency state is authoritativ
 5. Assign the earliest milestone in which the outcome is actually required.
 6. Apply `status:ready` only when all prerequisites and decisions are resolved.
 7. Move to `status:in-progress` when work starts; close through the implementing pull request.
-8. Review blocked and icebox work during milestone planning rather than through automated inactivity closure.
+8. Review dependency-blocked and icebox work during milestone planning rather than through automated inactivity closure.
 
 Issue stale-closing is disabled. Planned work should be closed only by an explicit product decision, completion, duplication, or supersession. Pull requests may still be marked stale so abandoned implementation branches remain visible.
 
@@ -150,10 +137,10 @@ Issue stale-closing is disabled. Planned work should be closed only by an explic
 At milestone boundaries, verify:
 
 - [ ] Open milestone issues have a single clear outcome and testable acceptance criteria.
-- [ ] Every open issue has one native parent.
+- [ ] Every non-root open issue has exactly one native parent; #282–#289 remain the root indexes.
 - [ ] Hard prerequisites use native dependencies and are absent from the body.
 - [ ] Exactly one scheduling model—the Milestone field—is in use.
 - [ ] No issue has more than one `status:*` label.
 - [ ] Completed, duplicate, and obsolete work is explicitly closed with a redirect comment.
-- [ ] Specifications are ratified before implementation issues carrying `blocked-by-spec` become ready.
+- [ ] A specification blocker is ratified before its dependent implementation issue becomes ready.
 - [ ] The active queue matches GitHub's dependency state.

--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -74,30 +74,30 @@ The upstream mapping document also uses review-planning labels:
 
 ## Current completeness
 
-| Area | Progress / target status | Tracking |
-|---|---|---|
-| Schema DSL — PostgreSQL column types | Partial — see [schema.md](./schema.md) and [codegen.md](./codegen.md) for current per-type status | M5 (#32, #137, #144) |
-| Schema DSL — MySQL column types | Partial — see [schema.md](./schema.md) and [codegen.md](./codegen.md) for current per-type status | M5 (#32) |
-| Schema DSL — SQLite column types | Mostly complete — see [schema.md](./schema.md) and [codegen.md](./codegen.md) for current per-type status | — |
-| Schema DSL — `generatedAlwaysAs` | Designed rejection — recognized in RC.1 snapshots but unsupported in initial schema input; fail with `unsupported_feature` | Unmilestoned (#172) |
-| Query builder — SELECT / INSERT / UPDATE / DELETE | Mostly complete target design — generated table/view/alias no-arg selects, non-recursive SELECT CTE SQL behavior, and dialect-supported FOR UPDATE/FOR SHARE target PARITY; Go CTE helper shape is DEVIATION:LANGUAGE; no-arg derived-source selects, no-arg joined select result shapes, mutation CTE builders, scalar subquery select-list helpers, insert runtime-hook omission, `INSERT ... SELECT`, SQLite ordered multiple conflict clauses, error-returning `Build`, and fail-fast dialect gating remain gaps; see [query-builder.md](./query-builder.md) for remaining gaps | — |
-| Query builder — missing operators | Not started — `NOT LIKE`, `NOT ILIKE`, `NOT BETWEEN` (P1); array helpers `arrayContains`, `arrayContained`, `arrayOverlaps` (designed); `WHERE` on `ON CONFLICT` (P1); `UPDATE…FROM` target design is now covered in [query-builder.md](./query-builder.md) but remains an implementation gap; `CROSS JOIN` (designed). Query-order `NULLS FIRST`/`NULLS LAST` would be GRIZZLE-ONLY if added; RC.1 uses those helpers for PostgreSQL index config, not query ordering. | M4 (#164, #163, #162, #167) |
-| Query builder — prepared statements | Designed — DEVIATION:GAP until param-capable operators/builders, `BuildPrepared`, ordered prepared-argument plans, per-execution `query.Params`, pgx reusable handles/registries, and MySQL/SQLite one-time prepared driver helpers are implemented | M6 (#166) |
-| Query builder — window frame spec | Not started — GRIZZLE-ONLY future extension; DEVIATION:GAP (not designed) | M6 (#139) |
-| Query builder — lateral join, cursor/streaming | Not started — DEVIATION:GAP (not designed) | M6 (#171, #170) |
-| Kit — legacy/current helpers (`diff` / `sql` / `snapshot` / `status`) | Implemented current surface; not part of the target RC.1 public file-migration workflow — see [docs/kit/overview.md](../kit/overview.md) and [kit.md](./kit.md) | — |
-| Kit — `migrate` | DEVIATION:BROKEN — current branch work reads migration SQL from a directory, but the full RC.1-style artifact, history, and validation contract is not yet implemented end-to-end | M3 (#154, P0) |
-| Kit — `generate` (write SQL migration files to disk) | Not started — DEVIATION:GAP (designed); highest-priority Kit gap | M3 (#153, P0) |
-| Kit — `push` CLI command | Public command surface retained, but new CLI/API work is blocked until a dedicated direct-sync safety spec exists | M3 (#157, P1) |
-| Kit — `pull` (DB → Go schema definitions) | Not started — DEVIATION:GAP (designed); introspection exists internally | M3 (#158, P1) |
-| Kit — `check` command | Not started — DEVIATION:GAP (designed); required before `generate` and `migrate`, with richer branch-collision value after artifacts exist | M3 (#169) |
-| Kit — rename resolution during `generate` | Not started — DEVIATION:GAP (designed); initial target is Drizzle RC.1-style interactive prompts, with non-interactive/config-based resolution deferred | M3 (#153, P0); track upstream follow-on in `sofired/grizzle#279` |
-| Relations — JOIN helpers (`JoinRel`, `InnerJoinRel`) | Implemented — GRIZZLE-ONLY (documented in query-builder.md) | — |
-| Relations — relational query API (`findMany`) | Not started — DEVIATION:GAP (not designed); manual batch-loading is the current approach | Not milestoned |
-| Code generation (`grizzle gen`) | Partially implemented for PostgreSQL, MySQL, and SQLite; current helper generation is narrower than the target static schema loader, resource-limit, managed-output safety, redacted diagnostics, nullable assignment, JSON/JSONB, and MySQL marker contracts — see [codegen.md](./codegen.md) | M3 follow-up |
-| Transactions — core callback shape | Implemented — PARITY for begin/callback/commit-or-rollback shape; DB/Tx row-vs-exec validation, nil/typed-nil handling, redacted error-code contract, and row ownership rules are specified target behavior but remain implementation gaps until the driver package satisfies [transactions.md](./transactions.md) | M6 follow-up |
-| Transactions — isolation levels | Not started — DEVIATION:GAP (designed) | M6 (#159, P1) |
-| Transactions — savepoints / nested transactions | Not started — DEVIATION:GAP (designed) | M6 (#143, P1) |
-| Transactions — MySQL / SQLite wrappers | Not started — DEVIATION:GAP (designed) | M6 (#160, P1) |
-| Dialects — PostgreSQL | PARITY target with listed gaps; required initial scope | — |
-| Dialects — MySQL / SQLite | DEVIATION:GAP (designed) for remaining column type gaps; target dialect interface rename/shim work and fail-fast dialect gating remain implementation gaps | M5 for type gaps |
+| Area | Progress / target status |
+|---|---|
+| Schema DSL — PostgreSQL column types | Partial — see [schema.md](./schema.md) and [codegen.md](./codegen.md) for current per-type status. |
+| Schema DSL — MySQL column types | Partial — see [schema.md](./schema.md) and [codegen.md](./codegen.md) for current per-type status. |
+| Schema DSL — SQLite column types | Mostly complete — see [schema.md](./schema.md) and [codegen.md](./codegen.md) for current per-type status. |
+| Schema DSL — `generatedAlwaysAs` | Designed rejection — recognized in RC.1 snapshots but unsupported in initial schema input; fail with `unsupported_feature`. |
+| Query builder — SELECT / INSERT / UPDATE / DELETE | Mostly complete target design — generated table/view/alias no-arg selects, non-recursive SELECT CTE SQL behavior, and dialect-supported FOR UPDATE/FOR SHARE target PARITY; Go CTE helper shape is DEVIATION:LANGUAGE; no-arg derived-source selects, no-arg joined select result shapes, mutation CTE builders, scalar subquery select-list helpers, insert runtime-hook omission, `INSERT ... SELECT`, SQLite ordered multiple conflict clauses, error-returning `Build`, and fail-fast dialect gating remain gaps; see [query-builder.md](./query-builder.md). |
+| Query builder — missing operators | `NOT LIKE`, `NOT ILIKE`, `NOT BETWEEN`, designed array helpers, conflict predicates, and `UPDATE…FROM` remain gaps. Query-order `NULLS FIRST`/`NULLS LAST` is GRIZZLE-ONLY; RC.1 uses those helpers for PostgreSQL index configuration rather than query ordering. |
+| Query builder — prepared statements | Designed — DEVIATION:GAP until param-capable operators/builders, `BuildPrepared`, ordered prepared-argument plans, per-execution `query.Params`, adaptation of pgx handles/registries, and MySQL/SQLite one-time prepared driver helpers are implemented. |
+| Query builder — window frame spec | Boundary sentinels exist, but typed frame construction remains a GRIZZLE-ONLY DEVIATION:GAP. |
+| Query builder — lateral join, cursor/streaming | DEVIATION:GAP (not designed); dialect scope and public APIs require ratification. |
+| Kit — legacy/current helpers (`diff` / `sql` / `snapshot` / `status`) | Implemented current surface; not part of the target RC.1 public file-migration workflow — see [docs/kit/overview.md](../kit/overview.md) and [kit.md](./kit.md). |
+| Kit — `migrate` | DEVIATION:BROKEN — current code does not yet implement the complete artifact, history, session, and validation contract end to end. |
+| Kit — `generate` | DEVIATION:GAP (designed); planning, typed rendering, and atomic artifact publication remain incomplete. |
+| Kit — `push` | Public implementation is intentionally deferred until a dedicated direct-sync safety specification is ratified. |
+| Kit — `pull` | DEVIATION:GAP (designed); introspection exists internally but the managed Pull workflow is incomplete. |
+| Kit — `check` | DEVIATION:GAP (designed); the reusable offline validation API and command handler remain incomplete. |
+| Kit — rename resolution during `generate` | DEVIATION:GAP (designed); initial behavior uses interactive resolution, while non-interactive/config-based resolution remains future scope. |
+| Relations — JOIN helpers (`JoinRel`, `InnerJoinRel`) | Implemented — GRIZZLE-ONLY, as documented in [query-builder.md](./query-builder.md). |
+| Relations — relational query API (`findMany`) | DEVIATION:GAP (not designed); manual batch loading is the current approach. |
+| Code generation (`grizzle gen`) | Partially implemented for PostgreSQL, MySQL, and SQLite; static schema metadata, resource limits, managed-output safety, redacted diagnostics, nullable assignments, JSON/JSONB, and MySQL marker contracts remain incomplete. |
+| Transactions — core callback shape | Implemented — PARITY for begin/callback/commit-or-rollback shape; validation, redacted error contracts, and row ownership still require conformance work. |
+| Transactions — isolation levels | DEVIATION:GAP (designed) across the public driver contract. |
+| Transactions — savepoints / nested transactions | DEVIATION:GAP (designed). |
+| Transactions — MySQL / SQLite wrappers | Generic `database/sql` wrappers exist; integration conformance and option mapping remain incomplete. |
+| Dialects — PostgreSQL | PARITY target with the listed gaps; required initial scope. |
+| Dialects — MySQL / SQLite | DEVIATION:GAP for remaining column types, interface reconciliation, and fail-fast capability gating. |

--- a/docs/spec/codegen.md
+++ b/docs/spec/codegen.md
@@ -307,7 +307,7 @@ Target semantics are Drizzle parity: callers must be able to omit a nullable fie
 | `interval` | `string` | DEVIATION:INTENTIONAL — PostgreSQL intervals can include months/years with no exact `time.Duration` equivalent; `string` preserves full fidelity |
 | `enum` (pg) | `string` | Generates `expr.EnumColumn` |
 | `tsvector`, `tsquery` | `string` | GRIZZLE-ONLY/source-generation support; RC.1 recognizes these type names/codecs but does not expose PostgreSQL column-builder helpers for them |
-| array | `any` | Generates `expr.ArrayColumn`; typed `[]T` generation is deferred (tracked in #144) |
+| array | `any` | Generates `expr.ArrayColumn`; typed `[]T` generation remains a separately designed gap. |
 | range types (`int4range`, `int8range`, `numrange`, `tsrange`, `tstzrange`, `daterange`) | `string` | GRIZZLE-ONLY — no Drizzle equivalent |
 
 MySQL integer mappings are dialect-specific and must not reuse PostgreSQL `serial` defaults:

--- a/docs/spec/dialects.md
+++ b/docs/spec/dialects.md
@@ -106,7 +106,7 @@ The rules below are the RC.1-parity target. Any current silent dropping or suppr
 
 ### JSONB operators — GRIZZLE-ONLY (PostgreSQL-specific typed convenience)
 
-`JSONBColumn[T]` and typed containment/existence/delete-path helpers (`@>`, `<@`, `?`, `?|`, `?&`, `#-`) are restricted to generated handles backed by `pg.JSONB()`. Drizzle RC.1 has distinct PostgreSQL `json()` and `jsonb()` builders, and PostgreSQL containment/existence/delete-path operators are JSONB-only. Plain `JSONColumn[T]` is the generated handle for plain JSON across supported dialects and must not expose JSONB-only helpers. Shared extraction helpers such as `->`, `->>`, `#>`, and `#>>` may be offered for PostgreSQL plain JSON if specified; otherwise plain JSON uses raw SQL or an explicit cast. Non-PostgreSQL builders should omit unsupported JSON helpers or return `unsupported_feature` rather than silently changing JSON semantics. Tracked as part of #140.
+`JSONBColumn[T]` and typed containment/existence/delete-path helpers (`@>`, `<@`, `?`, `?|`, `?&`, `#-`) are restricted to generated handles backed by `pg.JSONB()`. Drizzle RC.1 has distinct PostgreSQL `json()` and `jsonb()` builders, and PostgreSQL containment/existence/delete-path operators are JSONB-only. Plain `JSONColumn[T]` is the generated handle for plain JSON across supported dialects and must not expose JSONB-only helpers. Shared extraction helpers such as `->`, `->>`, `#>`, and `#>>` may be offered for PostgreSQL plain JSON if specified; otherwise plain JSON uses raw SQL or an explicit cast. Non-PostgreSQL builders should omit unsupported JSON helpers or return `unsupported_feature` rather than silently changing JSON semantics.
 
 ### Full-text search — GRIZZLE-ONLY (PostgreSQL-only)
 

--- a/docs/spec/dialects.md
+++ b/docs/spec/dialects.md
@@ -118,7 +118,7 @@ The rules below are the RC.1-parity target. Any current silent dropping or suppr
 
 ### Array operators — mixed DEVIATION:GAP status
 
-Broad array SQL features such as `ANY`, `ALL`, array subscripting, and typed array scan/generation are **DEVIATION:GAP (not designed)**. Public RC.1 condition helpers `arrayContains`, `arrayContained`, and `arrayOverlaps` are **DEVIATION:GAP (designed)**: when implemented, empty-array helper inputs must fail with `build_validation`, matching RC.1's throw behavior. Tracked as #144.
+Broad array SQL features such as `ANY`, `ALL`, array subscripting, and typed array scan/generation are **DEVIATION:GAP (not designed)**. Public RC.1 condition helpers `arrayContains`, `arrayContained`, and `arrayOverlaps` are **DEVIATION:GAP (designed)**: when implemented, empty-array helper inputs must fail with `build_validation`, matching RC.1's throw behavior.
 
 ## Current Implementation Status: `*pg.TableDef` Leak Across Dialects
 

--- a/docs/spec/file-migrations-implementation-sequence.md
+++ b/docs/spec/file-migrations-implementation-sequence.md
@@ -35,11 +35,11 @@ Prior work attempted to repurpose `migrate` before the rest of that workflow exi
 - Use Drizzle RC.1 source behavior as the default answer when implementation questions arise; any divergence must be documented before code changes.
 - Existing code, open PRs, and GitHub issues are triaged against this sequence before implementation starts. They are not implicitly accepted just because they already exist.
 - Exploratory prototypes are allowed only to answer implementation questions; they must not be promoted into production code until reconciled against the ratified specs.
-- Intermediate slices must remain easy to back out. If a slice stalls, either revert it or leave it behind non-command-path APIs until the missing spec or implementation dependency is resolved.
+- Intermediate milestone increments must remain easy to back out. If an increment stalls, either revert it or leave it behind non-command-path APIs until the missing spec or implementation dependency is resolved.
 
 ## GitHub And Existing-Code Triage
 
-Before Slice 0 implementation starts, the repository and GitHub backlog must be normalized against the ratified spec.
+Before Milestone 00 implementation starts, the repository and GitHub backlog must be normalized against the ratified spec.
 
 ### Existing Code
 
@@ -63,55 +63,54 @@ Every open PR touching migration, schema loading, codegen, query metadata, diale
 
 Classification:
 
-- `Merge after rebase`: aligns with the spec and belongs in the current or next slice.
-- `Split`: contains useful parts, but mixes multiple slices or unrelated cleanup.
+- `Merge after rebase`: aligns with the spec and belongs in the current or next milestone.
+- `Split`: contains useful parts, but mixes multiple milestones or unrelated cleanup.
 - `Rework`: useful intent, but implementation conflicts with the spec.
 - `Close / supersede`: implements the old checksum/live-diff approach, old artifact layout, unsafe migration behavior, or an unapproved divergence.
 
 Rules:
 
-- PRs must state which slice they implement
+- PRs must state which milestone outcome they advance
 - PRs must link to the relevant spec section
-- PRs must not mix workflow slices unless the dependency is unavoidable and documented
-- PRs that change public command meaning must wait until Slice 8 unless explicitly scoped as internal-only preparation
+- PRs must not mix milestone outcomes unless the dependency is unavoidable and documented
+- PRs that change public command meaning must wait until Milestone 09 unless explicitly scoped as internal-only preparation
 
 ### GitHub Issues
 
-Existing issues should be mapped into implementation slices and milestones.
+Existing issues should be mapped into the unified GitHub Milestones and native workstream hierarchy.
 
 Required labels or equivalent project fields:
 
-- `file-migrations`
-- `phase:implementation`
-- `slice:0` through `slice:8`
-- `spec-required` for issues that need a spec amendment before implementation
-- `blocked-by-spec` for issues intentionally deferred until a dedicated spec exists
+- `area:file-migrations` for file-migration work
+- `type:spec` for specification decisions
+- `status:ready`, `status:in-progress`, or `status:icebox` when a lifecycle state applies
 - `superseded` for issues made obsolete by the RC.1 file-migration decision
 
 Issue handling rules:
 
 - close or mark superseded issues that only track the discarded checksum-based migration direction
 - keep issues for genuine implementation gaps, but rewrite acceptance criteria to cite the ratified specs
-- create missing issues for each implementation slice before coding that slice
+- create missing issues for each milestone outcome before coding that outcome
 - direct-sync `push`, `export`, legacy upgrade support, and non-interactive rename resolution remain backlog items unless separately approved
 
 ### Triage Deliverable
 
 Create or update a GitHub project/milestone view with:
 
-- one parent issue per implementation slice
-- child issues for concrete implementation tasks
+- root workstream issues #282–#289 for navigation
+- exactly one native parent for every non-root issue
+- native sub-issues for concrete implementation tasks
 - linked PRs only after classification
-- explicit blockers for cross-slice dependencies
+- native blocked-by links for hard dependencies
 
 Exit criteria:
 
 - every open migration-related PR is classified
 - every migration-related issue is mapped, superseded, or deferred
-- Slice 0 has a concrete issue list ready for implementation
+- Milestone 00 has a concrete issue list ready for implementation
 - no open PR remains that can accidentally merge old-direction behavior into the new workflow
 
-## Slice 0: Package Boundary And Test Harness
+## Milestone 00: File-Migration Foundation
 
 Objective:
 Create a safe place to build the new workflow without letting existing migration behavior shape the target design.
@@ -119,7 +118,7 @@ Create a safe place to build the new workflow without letting existing migration
 Build:
 
 - internal/package boundaries for file-migration APIs defined in [file-migrations-api.md](./file-migrations-api.md)
-- stable error codes and redacted diagnostic carriers used by all later slices
+- stable error codes and redacted diagnostic carriers used by all later milestones
 - resource-limit structs and test fixtures
 - test filesystem/source/artifact stores with no-follow and containment behavior
 
@@ -129,7 +128,7 @@ Exit criteria:
 - new internal APIs compile but do not take over the CLI command path yet
 - tests can exercise stores, diagnostics, and limits without a database
 
-## Slice 1: Artifact Discovery And Offline Validation Core
+## Milestone 02: Artifact Discovery And Validation
 
 Objective:
 Implement the local artifact model before generating or applying anything.
@@ -149,7 +148,7 @@ Exit criteria:
 - malformed artifact cases produce stable redacted errors
 - no database connection is required
 
-## Slice 2: Snapshot And Schema Input Planning
+## Milestone 03: Snapshot And Schema Planning
 
 Objective:
 Produce and compare Grizzle snapshots without writing migration artifacts.
@@ -168,7 +167,7 @@ Exit criteria:
 - unsupported RC.1 fields fail before artifact writes
 - snapshot fixtures round-trip or fail exactly as specified
 
-## Slice 3: `check`
+## Milestone 04: `check`
 
 Objective:
 Make `check` the trusted offline gate for later mutating commands.
@@ -186,7 +185,7 @@ Exit criteria:
 - `check` catches malformed graphs and unsafe artifacts
 - `check` is callable by later `generate` and `migrate` code without CLI coupling
 
-## Slice 4: `generate`
+## Milestone 05: `generate`
 
 Objective:
 Create migration artifacts from schema definitions on top of `check`.
@@ -207,7 +206,7 @@ Exit criteria:
 - generated artifacts pass `check`
 - failed generation leaves no partial artifacts
 
-## Slice 5: History, Locking, And Migration Sessions
+## Milestone 06: Migration Sessions And History
 
 Objective:
 Prepare the database-side foundation before executing migrations.
@@ -227,7 +226,7 @@ Exit criteria:
 - unsupported or legacy history schemas fail as specified
 - concurrent migration attempts are serialized or fail safely
 
-## Slice 6: `migrate`
+## Milestone 07: `migrate`
 
 Objective:
 Apply reviewed artifacts safely.
@@ -247,9 +246,9 @@ Exit criteria:
 - generated artifacts can be applied end-to-end
 - applied migrations are skipped by name on later runs
 - failed runs surface deterministic state and diagnostics
-- only after this slice may the CLI `migrate` command be wired to the new workflow
+- only after this milestone may the CLI `migrate` command be wired to the new workflow
 
-## Slice 7: `pull` And `pull --init`
+## Milestone 08: `pull` And `pull --init`
 
 Objective:
 Add database-to-schema bootstrapping after the core artifact/history path exists.
@@ -269,7 +268,7 @@ Exit criteria:
 - `pull --init` records reviewed bootstrap state without executing its SQL
 - broad-scan diagnostics and object refs follow the redaction contract
 
-## Slice 8: CLI Cutover And Cleanup
+## Milestone 09: CLI Cutover And Release
 
 Objective:
 Expose the completed RC.1-style workflow and remove ambiguity.
@@ -298,7 +297,7 @@ Exit criteria:
 
 ## Implementation Test Matrix
 
-Each slice should add focused tests for the behavior it owns. Before the CLI cutover, the implementation should have coverage for:
+Each milestone should add focused tests for the behavior it owns. Before the CLI cutover, the implementation should have coverage for:
 
 - generation from an empty state
 - generation from prior snapshot and artifact state

--- a/docs/spec/file-migrations-implementation-sequence.md
+++ b/docs/spec/file-migrations-implementation-sequence.md
@@ -1,14 +1,16 @@
 # File Migrations Implementation Sequence
 
-This document is the Phase 4 implementation sequencing plan for the Drizzle RC.1-style file-migration workflow.
+This document is the implementation sequencing plan for the Drizzle RC.1-style file-migration workflow.
 
 The implementation target is the spec package rooted at [kit.md](./kit.md), with behavior pinned to Drizzle ORM / Drizzle Kit `v1.0.0-rc.1`.
 
 ## Status
 
-- Phase 2 target specs are complete.
-- Phase 3 broad documentation review found no remaining Medium or High findings.
+- The historical Phase 2 target-spec pass is complete.
+- The historical Phase 3 broad documentation review found no remaining Medium or High findings.
 - Remaining implementation work should proceed in the sequence below unless the project owner explicitly changes the order.
+
+The Phase 2/3 wording above identifies completed specification-review passes, not a second delivery schedule. GitHub Milestones are the only scheduling model. Milestone 01 is cross-cutting backlog and API governance, so it has no file-migration implementation section here; the workflow sequence intentionally moves from the completed Milestone 00 foundation to Milestone 02.
 
 ## Rationale
 

--- a/docs/spec/query-builder.md
+++ b/docs/spec/query-builder.md
@@ -403,7 +403,8 @@ Drizzle RC.1 does not expose public typed helpers such as `rowNumber().over(...)
 |---|---|---|
 | raw `` sql`row_number() over (...)` `` / `` sql`rank() over (...)` `` | typed wrappers such as `expr.RowNumber().PartitionBy(...).OrderBy(...)` and `expr.Rank()` | GRIZZLE-ONLY typed convenience over raw SQL parity |
 | raw `` sql`lag(${col}) over (...)` `` / `` sql`lead(${col}) over (...)` `` | `expr.Lag(col, ...)`, `expr.Lead(col, ...)` | GRIZZLE-ONLY typed convenience over raw SQL parity |
-| raw `` sql`first_value(${col}) over (...)` `` and related navigation functions | `expr.FirstValue(col)`, `expr.LastValue(col)`, `expr.NthValue(col, n)`, `expr.Ntile(n)`, `expr.PercentRank()`, `expr.CumeDist()` | GRIZZLE-ONLY typed convenience over raw SQL parity |
+| raw `` sql`first_value(${col}) over (...)` `` and related navigation functions | `expr.FirstValue(col)`, `expr.LastValue(col)`, `expr.NthValue(col, n)` | GRIZZLE-ONLY typed convenience over raw SQL parity |
+| raw `` sql`ntile(${n}) over (...)` ``, `` sql`percent_rank() over (...)` ``, and `` sql`cume_dist() over (...)` `` | planned `expr.Ntile(n)`, `expr.PercentRank()`, and `expr.CumeDist()` | GRIZZLE-ONLY typed convenience; DEVIATION:GAP (designed) until implemented |
 | raw SQL `PARTITION BY` / `ORDER BY` inside `OVER (...)` | `.PartitionBy(cols...)` / `.OrderBy(cols...)` on typed window expressions | GRIZZLE-ONLY typed convenience |
 | raw SQL frame spec (`ROWS` / `RANGE` / `GROUPS BETWEEN`) | typed frame API | GRIZZLE-ONLY future extension; DEVIATION:GAP (not designed) until the frame API is specified (#139) |
 | *(no Drizzle equivalent)* | `expr.WinSum(col)` | GRIZZLE-ONLY — see below |

--- a/docs/spec/schema.md
+++ b/docs/spec/schema.md
@@ -91,7 +91,7 @@ In Drizzle, the column name is the first argument to the type function: `uuid('i
 | `bit(name, { dimensions })` | DEVIATION:GAP (not designed) | — |
 | `sparsevec(name, { dimensions })` | DEVIATION:GAP (not designed) | — |
 | *(no exported RC.1 PostgreSQL column builder)* | `pg.Tsvector()` | GRIZZLE-ONLY — PostgreSQL `tsvector` storage column/source-generation support; Go type `string`; typed FTS helpers remain PostgreSQL-only Grizzle conveniences |
-| Array types (`.array()` / `.array('[][]')`) | `pg.Array(inner, dimensions?)` or equivalent | PARITY target for one-dimensional arrays; explicit multidimensional dimension strings are DEVIATION:GAP until specified/implemented; Go type `any`; typed `[]T` generation tracked in #144 |
+| Array types (`.array()` / `.array('[][]')`) | `pg.Array(inner, dimensions?)` or equivalent | PARITY target for one-dimensional arrays; explicit multidimensional dimension strings are DEVIATION:GAP until specified/implemented; Go type `any`; typed `[]T` generation remains a separate gap. |
 | Custom types (`.customType()`) | DEVIATION:GAP (not designed) | — |
 | *(no Drizzle equivalent)* | `pg.Tsquery()` | GRIZZLE-ONLY — PostgreSQL `tsquery` storage column; Go type `string` |
 | *(no Drizzle equivalent)* | `pg.Int4Range()`, `pg.Int8Range()`, `pg.NumRange()`, `pg.TsRange()`, `pg.TstzRange()`, `pg.DateRange()` | GRIZZLE-ONLY — PostgreSQL range types; Go type `string` |

--- a/docs/spec/schema.md
+++ b/docs/spec/schema.md
@@ -101,12 +101,12 @@ In Drizzle, the column name is the first argument to the type function: `uuid('i
 | Drizzle | Grizzle | Status |
 |---|---|---|
 | `mysqlTable(name, cols)` | `mysql.Table(name, cols...)` | PARITY |
-| `int(name, { unsigned? })` | `mysql.Int()` plus unsigned option | PARITY for DDL and generated signed/unsigned Go type mapping; see [codegen.md](./codegen.md#go-type-mappings) |
+| `int(name, { unsigned? })` | `mysql.Integer()` plus unsigned option | PARITY target; DEVIATION:GAP because the current re-exported PostgreSQL builder has no MySQL unsigned representation or generated unsigned Go type mapping |
 | `varchar(name, { length, enum? })` | `mysql.Varchar(n)` plus Go enum/type policy | PARITY for DDL; Drizzle `enum` is TypeScript type narrowing and maps to Go codegen/type policy as DEVIATION:LANGUAGE until represented |
 | `text(name, { enum? })` | `mysql.Text()` plus Go enum/type policy | PARITY for DDL; Drizzle `enum` is TypeScript type narrowing and maps to Go codegen/type policy as DEVIATION:LANGUAGE until represented |
 | `boolean(name)` | `mysql.Boolean()` | PARITY |
 | `timestamp(name, { mode?, fsp? })` | `mysql.Timestamp()` plus mode/fsp mapping | PARITY for DDL; mode/fsp API coverage is DEVIATION:GAP until specified |
-| `bigint(name, { mode, unsigned? })` | `mysql.BigInt()` plus mode/unsigned mapping | PARITY for DDL and generated signed/unsigned Go type mapping; Drizzle mode-specific API behavior remains DEVIATION:GAP until represented |
+| `bigint(name, { mode, unsigned? })` | `mysql.BigInt()` plus mode/unsigned mapping | PARITY target; DEVIATION:GAP until mode, unsigned DDL, and generated signed/unsigned Go type behavior are represented |
 | `serial(name)` | `mysql.Serial()` | PARITY for DDL; generated Go type `uint64` is DEVIATION:LANGUAGE from RC.1's JavaScript `number`/uint53 surface to preserve MySQL's unsigned physical range |
 | `datetime(name, { mode?, fsp? })` | `mysql.DateTime()` plus mode/fsp mapping | PARITY target; DEVIATION:GAP until API/options are specified/implemented |
 | `date(name, { mode? })` | `mysql.Date()` plus mode-specific Go type mapping | PARITY target for DDL; mode is a type/API mapping concern and is DEVIATION:GAP until specified/implemented |
@@ -117,9 +117,9 @@ In Drizzle, the column name is the first argument to the type function: `uuid('i
 | `real(name, { precision?, scale? })` | `mysql.Real()` plus precision/scale options | PARITY target; DEVIATION:GAP until API/options are specified/implemented |
 | `decimal(name, { precision?, scale?, unsigned?, mode? })` | `mysql.Decimal(precision?, scale?)` plus unsigned/mode-specific Go type mapping | PARITY target; DEVIATION:GAP until API/options are specified/implemented |
 | `json(name)` | `mysql.JSON()` | PARITY target; DEVIATION:GAP until implemented |
-| `mediumint(name, { unsigned? })` | `mysql.MediumInt()` plus unsigned option | PARITY for DDL and generated signed/unsigned Go type mapping |
-| `smallint(name, { unsigned? })` | `mysql.SmallInt()` plus unsigned option | PARITY target for DDL and generated signed/unsigned Go type mapping; DEVIATION:GAP until builder coverage is implemented if missing |
-| `tinyint(name, { unsigned? })` | `mysql.TinyInt()` plus unsigned option | PARITY target for DDL and generated signed/unsigned Go type mapping; DEVIATION:GAP until builder coverage is implemented if missing |
+| `mediumint(name, { unsigned? })` | `mysql.MediumInt()` plus unsigned option | PARITY target; DEVIATION:GAP until unsigned DDL and generated unsigned Go type mapping are implemented |
+| `smallint(name, { unsigned? })` | `mysql.SmallInt()` plus unsigned option | PARITY target; DEVIATION:GAP until unsigned DDL and generated unsigned Go type mapping are implemented |
+| `tinyint(name, { unsigned? })` | `mysql.TinyInt()` plus unsigned option | PARITY target; DEVIATION:GAP until unsigned DDL and generated unsigned Go type mapping are implemented |
 | `binary(name)` | DEVIATION:GAP (not designed) | — |
 | `varbinary(name)` | DEVIATION:GAP (not designed) | — |
 | `blob(name)` | DEVIATION:GAP (not designed) | — |

--- a/docs/spec/transactions.md
+++ b/docs/spec/transactions.md
@@ -16,7 +16,7 @@ Drizzle wraps the callback in a transaction and automatically commits on success
 
 ## Grizzle Callback Shape — PARITY
 
-The callback transaction shape below is implemented parity for PostgreSQL: begin a transaction, run the callback, commit on nil, and roll back on error. The stricter DB/Tx row-vs-exec validation, nil/typed-nil checks, redacted stable transaction errors, row ownership rules, isolation options, savepoints, and MySQL/SQLite wrappers are target implementation gaps until the driver packages satisfy the contracts below.
+The callback transaction shape below is implemented for PostgreSQL and through the generic `database/sql` wrapper used by MySQL and SQLite: begin a transaction, run the callback, commit on nil, and roll back on error. Stricter DB/Tx row-vs-exec validation, nil/typed-nil checks, redacted stable transaction errors, row ownership rules, isolation-option mapping, savepoints, and cross-driver conformance remain target implementation gaps until the driver packages satisfy the contracts below.
 
 ```go
 err := db.Transaction(ctx, func(tx *pgxdb.Tx) error {
@@ -124,4 +124,4 @@ Not yet implemented. Tracked as **#143**.
 
 ## MySQL and SQLite
 
-MySQL and SQLite transactions follow the same callback shape through their driver packages. The PostgreSQL implementation is exposed as `(*pgxdb.DB).Transaction` and uses `pgxpool` internally. Equivalent wrappers for MySQL and SQLite are **DEVIATION:GAP (designed)** — the API should be identical; only the underlying driver call differs.
+MySQL and SQLite transactions follow the same callback shape through the generic `driver/sql` wrapper; PostgreSQL exposes `(*pgxdb.DB).Transaction` over pgx. The generic wrappers exist. Dialect-specific option mapping, strict validation/error semantics, and integration conformance remain **DEVIATION:GAP (designed)** work; callers should not infer complete cross-driver parity from the shared callback shape alone.

--- a/kit/filemigrate/doc.go
+++ b/kit/filemigrate/doc.go
@@ -2,9 +2,9 @@
 // workflow. It is the Go equivalent of Drizzle Kit's generate/migrate/check/pull
 // command surface.
 //
-// # Slice 0 scope
+// # Milestone 00 scope
 //
-// This package currently contains only the foundation required by Slice 0 of
+// This package currently contains only the foundation required by Milestone 00 of
 // the implementation sequence defined in docs/spec/file-migrations-implementation-sequence.md:
 //
 //   - Stable [ErrorCode] constants and [Error] / [ExecutionError] / [PartialApplicationError] types
@@ -22,7 +22,7 @@
 // This package must not import or reuse the legacy kit.Snapshot, kit.SaveJSON,
 // kit.LoadJSON, kit.MigrationsTable, or kit.ChecksumSQL symbols. Those are
 // quarantined pending a separate cutover. The two code paths coexist in the
-// repository until Slice 8 wires the CLI to this package.
+// repository until Milestone 09 wires the CLI to this package.
 //
 // # Error contract
 //

--- a/kit/filemigrate/doc.go
+++ b/kit/filemigrate/doc.go
@@ -2,10 +2,10 @@
 // workflow. It is the Go equivalent of Drizzle Kit's generate/migrate/check/pull
 // command surface.
 //
-// # Milestone 00 scope
+// # Current foundation
 //
-// This package currently contains only the foundation required by Milestone 00 of
-// the implementation sequence defined in docs/spec/file-migrations-implementation-sequence.md:
+// This package currently contains the foundation for the implementation
+// sequence defined in docs/spec/file-migrations-implementation-sequence.md:
 //
 //   - Stable [ErrorCode] constants and [Error] / [ExecutionError] / [PartialApplicationError] types
 //   - [CodeSentinel] values for programmatic errors.Is classification
@@ -14,15 +14,15 @@
 //   - [ArtifactStore] and [ManagedSourceStore] interfaces
 //   - Filesystem-backed and in-memory store implementations
 //
-// Later slices will add artifact discovery, snapshot validation, check, generate,
-// migrate, and pull implementations on top of this foundation.
+// Artifact discovery, snapshot validation, check, generate, migrate, and pull
+// implementations build on this foundation.
 //
 // # Isolation constraint
 //
 // This package must not import or reuse the legacy kit.Snapshot, kit.SaveJSON,
 // kit.LoadJSON, kit.MigrationsTable, or kit.ChecksumSQL symbols. Those are
 // quarantined pending a separate cutover. The two code paths coexist in the
-// repository until Milestone 09 wires the CLI to this package.
+// repository until the CLI cutover is complete.
 //
 // # Error contract
 //


### PR DESCRIPTION
## Summary

- adopt GitHub Milestones 00–09 as the only scheduling model and remove the retired milestone set
- make native parent/sub-issue and blocked-by relationships authoritative instead of duplicating dependency lists in issue bodies
- document the title, scope, acceptance-criteria, label, lifecycle, and triage standards applied to the complete open backlog
- align the normative implementation sequence, specification index, package documentation, contributor guidance, and issue forms with that model
- disable inactivity processing for issues while retaining independent pull-request stale handling
- absorb the current `actions/stale` 10.4.0 update

## Backlog refinement applied

- reviewed every open issue and assigned exactly one native parent to every non-root issue; #282–#289 remain the intentional workstream roots
- rewrote generic or inaccurate issues with bounded outcomes, explicit in/out scope, and testable acceptance criteria
- corrected native dependency direction, removed redundant transitive edges, and added the missing query build/render contract
- separated plain-Pull delivery from Pull initialization orchestration while preserving one public Pull API, split MySQL temporal from numeric column options, and added focused array and CLI-redaction coverage
- created #447–#453; closed completed or superseded #160 and #443 with redirect comments; reopened #140/#141 after final code verification and converted undefined public contracts to spec-first work
- retired redundant blocked-state labels; milestone assignment now means scheduled, while `status:ready`, `status:in-progress`, and `status:icebox` remain the only execution-state labels

## Validation

- `go test ./...`
- `go vet ./...`
- parsed every repository YAML file with PyYAML
- `git diff --check`
- audited all open issues for native parents, at most one lifecycle status, milestone/icebox exclusivity, generic acceptance-criteria boilerplate, body-level dependency sections, and dependency cycles

Tracks #432
Closes #433
