### PR TITLE
fix(kit): ignore defaults when both are absent

### DIFF
--- a/kit/diff.go
+++ b/kit/diff.go
@@ -660,7 +660,8 @@ func diffColumn(tableName string, old, new pg.ColumnDef) []Change {
 			NewCol:     &n,
 		})
 	}
-	if normalizeDefaultExpr(old.DefaultExpr) != normalizeDefaultExpr(new.DefaultExpr) || old.HasDefault != new.HasDefault {
+	if old.HasDefault != new.HasDefault ||
+		(old.HasDefault && new.HasDefault && normalizeDefaultExpr(old.DefaultExpr) != normalizeDefaultExpr(new.DefaultExpr)) {
 		o, n := old, new
 		changes = append(changes, Change{
 			Kind:       ChangeAlterColumnDefault,

--- a/kit/diff_default_test.go
+++ b/kit/diff_default_test.go
@@ -1,0 +1,205 @@
+package kit_test
+
+import (
+	"testing"
+
+	"github.com/sofired/grizzle/kit"
+	"github.com/sofired/grizzle/schema/pg"
+)
+
+func TestDiff_DefaultPresenceControlsExpressionComparison(t *testing.T) {
+	cases := []struct {
+		name                   string
+		oldHasDefault          bool
+		oldExpr                string
+		newHasDefault          bool
+		newExpr                string
+		wantAlterColumnDefault bool
+	}{
+		{
+			name:    "both_has_default_false_ignore_residual_expression_text",
+			oldExpr: "",
+			newExpr: "ignored residual text",
+		},
+		{
+			name:                   "add_non_null_default",
+			oldExpr:                "ignored residual text",
+			newHasDefault:          true,
+			newExpr:                "'pending'",
+			wantAlterColumnDefault: true,
+		},
+		{
+			name:                   "remove_non_null_default",
+			oldHasDefault:          true,
+			oldExpr:                "'pending'",
+			newExpr:                "ignored residual text",
+			wantAlterColumnDefault: true,
+		},
+		{
+			name:                   "change_non_null_default_expression",
+			oldHasDefault:          true,
+			oldExpr:                "'pending'",
+			newHasDefault:          true,
+			newExpr:                "'active'",
+			wantAlterColumnDefault: true,
+		},
+		{
+			name:          "same_non_null_default_is_unchanged",
+			oldHasDefault: true,
+			oldExpr:       "'pending'",
+			newHasDefault: true,
+			newExpr:       "'pending'",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			changes := diffSingleColumnDefault(
+				tc.oldHasDefault,
+				tc.oldExpr,
+				tc.newHasDefault,
+				tc.newExpr,
+			)
+			requireAlterColumnDefault(
+				t,
+				changes,
+				tc.wantAlterColumnDefault,
+				tc.oldHasDefault,
+				tc.oldExpr,
+				tc.newHasDefault,
+				tc.newExpr,
+			)
+		})
+	}
+}
+
+// TestDiff_ExplicitNullDefaultPresence uses representative legacy snapshot
+// expressions for PostgreSQL, MySQL, and SQLite. It does not exercise live
+// introspection, database connections, or dialect SQL generation.
+func TestDiff_ExplicitNullDefaultPresence(t *testing.T) {
+	expressionStyles := []struct {
+		name         string
+		explicitNull string
+	}{
+		{name: "postgresql_style_expression", explicitNull: "NULL::text"},
+		{name: "mysql_style_expression", explicitNull: "NULL"},
+		{name: "sqlite_style_expression", explicitNull: "NULL"},
+	}
+
+	for _, style := range expressionStyles {
+		t.Run(style.name, func(t *testing.T) {
+			cases := []struct {
+				name                   string
+				oldHasDefault          bool
+				oldExpr                string
+				newHasDefault          bool
+				newExpr                string
+				wantAlterColumnDefault bool
+			}{
+				{
+					name:    "both_has_default_false_ignore_null_expression_text",
+					newExpr: style.explicitNull,
+				},
+				{
+					name:                   "add_explicit_null_when_presence_becomes_true",
+					oldExpr:                style.explicitNull,
+					newHasDefault:          true,
+					newExpr:                style.explicitNull,
+					wantAlterColumnDefault: true,
+				},
+				{
+					name:                   "remove_explicit_null_when_presence_becomes_false",
+					oldHasDefault:          true,
+					oldExpr:                style.explicitNull,
+					newExpr:                style.explicitNull,
+					wantAlterColumnDefault: true,
+				},
+				{
+					name:          "same_explicit_null_default_is_unchanged",
+					oldHasDefault: true,
+					oldExpr:       style.explicitNull,
+					newHasDefault: true,
+					newExpr:       style.explicitNull,
+				},
+			}
+
+			for _, tc := range cases {
+				t.Run(tc.name, func(t *testing.T) {
+					changes := diffSingleColumnDefault(
+						tc.oldHasDefault,
+						tc.oldExpr,
+						tc.newHasDefault,
+						tc.newExpr,
+					)
+					requireAlterColumnDefault(
+						t,
+						changes,
+						tc.wantAlterColumnDefault,
+						tc.oldHasDefault,
+						tc.oldExpr,
+						tc.newHasDefault,
+						tc.newExpr,
+					)
+				})
+			}
+		})
+	}
+}
+
+func diffSingleColumnDefault(oldHasDefault bool, oldExpr string, newHasDefault bool, newExpr string) []kit.Change {
+	snapshot := func(hasDefault bool, defaultExpr string) kit.Snapshot {
+		return kit.Snapshot{
+			Version: "1",
+			Tables: map[string]*kit.TableSnap{
+				"items": {
+					Name: "items",
+					Columns: []pg.ColumnDef{
+						{
+							Name:        "status",
+							SQLType:     "text",
+							HasDefault:  hasDefault,
+							DefaultExpr: defaultExpr,
+						},
+					},
+				},
+			},
+		}
+	}
+
+	return kit.Diff(snapshot(oldHasDefault, oldExpr), snapshot(newHasDefault, newExpr))
+}
+
+func requireAlterColumnDefault(
+	t *testing.T,
+	changes []kit.Change,
+	want bool,
+	oldHasDefault bool,
+	oldExpr string,
+	newHasDefault bool,
+	newExpr string,
+) {
+	t.Helper()
+	if !want {
+		if len(changes) != 0 {
+			t.Fatalf(
+				"expected no changes for HasDefault=%t DefaultExpr=%q -> HasDefault=%t DefaultExpr=%q; got %v",
+				oldHasDefault,
+				oldExpr,
+				newHasDefault,
+				newExpr,
+				changes,
+			)
+		}
+		return
+	}
+	if len(changes) != 1 || changes[0].Kind != kit.ChangeAlterColumnDefault {
+		t.Fatalf(
+			"expected one AlterColumnDefault for HasDefault=%t DefaultExpr=%q -> HasDefault=%t DefaultExpr=%q; got %v",
+			oldHasDefault,
+			oldExpr,
+			newHasDefault,
+			newExpr,
+			changes,
+		)
+	}
+}


### PR DESCRIPTION
## Summary

- treat `HasDefault` as the authoritative indication that a column default exists
- compare normalized default expressions only when both columns have defaults
- add regression coverage for absent, added, removed, changed, and unchanged defaults
- distinguish absent defaults from representative PostgreSQL, MySQL, and SQLite explicit-NULL expressions

## Root cause

The legacy diff path compared normalized `DefaultExpr` values even when both columns had `HasDefault == false`. Residual or dialect-shaped expression text could therefore produce a spurious `AlterColumnDefault` change despite neither column having a default.

## Impact

Two absent defaults no longer produce a schema change. Existing add, remove, and change detection remains intact.

## Validation

- `gofmt -d kit/diff.go kit/diff_default_test.go`
- `go vet ./...`
- `go test -race -count=1 ./...`
- `git diff --check origin/main...HEAD`

`golangci-lint` was not available locally; the pull-request CI workflow runs the pinned linter.

## Local peer review

- Lead architect: **APPROVE**
- Senior software engineer: **APPROVE**
- Technical writer: **APPROVE**

Closes #244
