### PR TITLE
test(schema): cover MySQL and SQLite TableDef contracts

### DIFF
--- a/schema/mysql/mysql_test.go
+++ b/schema/mysql/mysql_test.go
@@ -232,6 +232,29 @@ func TestTable_Build(t *testing.T) {
 	}
 }
 
+func TestTable_DialectAndDef(t *testing.T) {
+	tbl := mysql.SchemaTable("inventory", "widgets",
+		mysql.C("id", mysql.Integer().PrimaryKey()),
+	).Build()
+
+	if got := tbl.Dialect(); got != "mysql" {
+		t.Errorf("Dialect: got %q, want %q", got, "mysql")
+	}
+	def := tbl.Def()
+	if def == nil {
+		t.Fatal("Def: got nil, want underlying table definition")
+	}
+	if def != tbl.TableDef {
+		t.Error("Def: did not return the embedded table definition")
+	}
+	if def.Schema != "inventory" || def.Name != "widgets" {
+		t.Errorf("Def table metadata: got %q.%q, want %q.%q", def.Schema, def.Name, "inventory", "widgets")
+	}
+	if len(def.Columns) != 1 || def.Columns[0].Name != "id" {
+		t.Fatalf("Def columns: got %+v, want one id column", def.Columns)
+	}
+}
+
 func TestTable_WithConstraints(t *testing.T) {
 	tbl := mysql.Table("users",
 		mysql.C("id", mysql.UUID().PrimaryKey().DefaultRandom()),

--- a/schema/sqlite/sqlite_test.go
+++ b/schema/sqlite/sqlite_test.go
@@ -206,6 +206,29 @@ func TestTable_Build(t *testing.T) {
 	}
 }
 
+func TestTable_DialectAndDef(t *testing.T) {
+	tbl := sqlite.SchemaTable("archive", "events",
+		sqlite.C("id", sqlite.Integer().PrimaryKey()),
+	).Build()
+
+	if got := tbl.Dialect(); got != "sqlite" {
+		t.Errorf("Dialect: got %q, want %q", got, "sqlite")
+	}
+	def := tbl.Def()
+	if def == nil {
+		t.Fatal("Def: got nil, want underlying table definition")
+	}
+	if def != tbl.TableDef {
+		t.Error("Def: did not return the embedded table definition")
+	}
+	if def.Schema != "archive" || def.Name != "events" {
+		t.Errorf("Def table metadata: got %q.%q, want %q.%q", def.Schema, def.Name, "archive", "events")
+	}
+	if len(def.Columns) != 1 || def.Columns[0].Name != "id" {
+		t.Fatalf("Def columns: got %+v, want one id column", def.Columns)
+	}
+}
+
 func TestTable_WithConstraints(t *testing.T) {
 	tbl := sqlite.Table("users",
 		sqlite.C("id", sqlite.Integer().PrimaryKey()),


### PR DESCRIPTION
## Summary

- add focused MySQL and SQLite tests for the public `TableDef.Dialect()` contract
- verify `Def()` returns the embedded table definition with the expected metadata and columns
- keep the coverage in each owning schema package so failures are independent of parser tests

## Impact

This adds direct regression coverage for the dialect and definition contracts without changing production behavior.

## Validation

- `go test ./schema/mysql ./schema/sqlite`
- `go test ./...`
- `go vet ./...`
- `git diff --check`

Closes #183