### PR TITLE
fix(query): reject unsafe identifiers during SQL construction

### DIFF
--- a/driver/pgx/prepared_execution_test.go
+++ b/driver/pgx/prepared_execution_test.go
@@ -28,6 +28,15 @@ func invalidSelectBuilder() *query.SelectBuilder {
 	return query.Select().Where(expr.RawArgs("x = $? AND y = $?", 1))
 }
 
+type invalidIdentifierTable string
+
+func (t invalidIdentifierTable) GrizTableName() string  { return string(t) }
+func (t invalidIdentifierTable) GrizTableAlias() string { return string(t) }
+
+func invalidIdentifierSelectBuilder() *query.SelectBuilder {
+	return query.Select().From(invalidIdentifierTable("unsafe\nidentifier"))
+}
+
 type typedNilBuilder struct{}
 
 func (*typedNilBuilder) Build(dialect.Dialect) (string, []any, error) {
@@ -53,6 +62,49 @@ func TestPreparedHelpers_PropagateBuildErrorsBeforeDatabaseUse(t *testing.T) {
 	}
 	if len(reg.entries) != 0 {
 		t.Fatalf("failed registrations mutated registry: %v", reg.entries)
+	}
+}
+
+func TestPreparedHelpers_PreserveInvalidIdentifierCodeAndRedaction(t *testing.T) {
+	ctx := context.Background()
+	builder := invalidIdentifierSelectBuilder()
+	_, _, normalErr := builder.Build(dialect.Postgres)
+	assertInvalidIdentifierError(t, normalErr)
+
+	if stmt, err := PrepareSelect[any](ctx, nil, "invalid_identifier", builder); stmt != nil {
+		t.Fatalf("PrepareSelect returned statement: %v", stmt)
+	} else {
+		assertInvalidIdentifierError(t, err)
+	}
+	if stmt, err := PrepareExec(ctx, nil, "invalid_identifier", builder); stmt != nil {
+		t.Fatalf("PrepareExec returned statement: %v", stmt)
+	} else {
+		assertInvalidIdentifierError(t, err)
+	}
+
+	reg := NewRegistry(nil)
+	if stmt, err := RegisterSelect[any](reg, "invalid_identifier", builder); stmt != nil {
+		t.Fatalf("RegisterSelect returned statement: %v", stmt)
+	} else {
+		assertInvalidIdentifierError(t, err)
+	}
+	if stmt, err := RegisterExec(reg, "invalid_identifier", builder); stmt != nil {
+		t.Fatalf("RegisterExec returned statement: %v", stmt)
+	} else {
+		assertInvalidIdentifierError(t, err)
+	}
+	if len(reg.entries) != 0 {
+		t.Fatalf("failed registrations mutated registry: %v", reg.entries)
+	}
+}
+
+func assertInvalidIdentifierError(t *testing.T, err error) {
+	t.Helper()
+	if !errors.Is(err, query.ErrInvalidIdentifier) {
+		t.Fatalf("error = %v, want ErrInvalidIdentifier", err)
+	}
+	if strings.Contains(err.Error(), "unsafe") || strings.ContainsAny(err.Error(), "\n\r\x00\x1b") {
+		t.Fatalf("error leaked unsafe identifier data: %q", err)
 	}
 }
 

--- a/query/identifier_validation_test.go
+++ b/query/identifier_validation_test.go
@@ -1,0 +1,171 @@
+package query_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/sofired/grizzle/dialect"
+	"github.com/sofired/grizzle/expr"
+	"github.com/sofired/grizzle/query"
+)
+
+type identifierTable struct {
+	name  string
+	alias string
+}
+
+func (t identifierTable) GrizTableName() string  { return t.name }
+func (t identifierTable) GrizTableAlias() string { return t.alias }
+
+type identifierRow struct {
+	Name string `db:"name"`
+}
+
+type dottedIdentifierRow struct {
+	Value string `db:"unsafe.identifier"`
+}
+
+func TestBuild_InvalidIdentifierClassesFailClosedAndRedacted(t *testing.T) {
+	invalid := []struct {
+		name  string
+		value string
+	}{
+		{name: "empty", value: ""},
+		{name: "dotted", value: "audit.users"},
+		{name: "nul", value: "nul\x00byte"},
+		{name: "line_feed", value: "line\nfeed"},
+		{name: "carriage_return", value: "carriage\rreturn"},
+		{name: "delete", value: "delete\x7fchar"},
+		{name: "c0_control", value: "control\x01char"},
+		{name: "c1_control", value: "control\u0085char"},
+	}
+
+	for _, invalidPart := range invalid {
+		t.Run(invalidPart.name, func(t *testing.T) {
+			table := identifierTable{name: invalidPart.value, alias: invalidPart.value}
+			aliasedTable := identifierTable{name: "users", alias: invalidPart.value}
+			builders := map[string]query.Builder{
+				"select_name":  query.Select().From(table),
+				"insert_name":  query.InsertInto(table).Values(identifierRow{Name: "sensitive-value"}),
+				"update_name":  query.Update(table).Set("name", "sensitive-value"),
+				"delete_name":  query.DeleteFrom(table),
+				"select_alias": query.Select().From(aliasedTable),
+				"insert_alias": query.InsertInto(aliasedTable).Values(identifierRow{Name: "sensitive-value"}),
+				"update_alias": query.Update(aliasedTable).Set("name", "sensitive-value"),
+				"delete_alias": query.DeleteFrom(aliasedTable),
+				"set_operation": query.Select().From(table).
+					Union(query.Select().From(identifierTable{name: "users", alias: "users"})),
+			}
+			for name, builder := range builders {
+				t.Run(name, func(t *testing.T) {
+					assertInvalidIdentifierBuild(t, builder, dialect.Postgres, invalidPart.value)
+				})
+			}
+		})
+	}
+}
+
+func TestBuild_AllIdentifierBearingSurfacesUseValidation(t *testing.T) {
+	const unsafe = "unsafe\nidentifier"
+	validTable := identifierTable{name: "users", alias: "users"}
+	unsafeAliasTable := identifierTable{name: "users", alias: unsafe}
+	validColumn := expr.StringColumn{ColBase: expr.ColBase{TableAlias: "users", ColName: "name"}}
+	unsafeTableColumn := expr.StringColumn{ColBase: expr.ColBase{TableAlias: unsafe, ColName: "name"}}
+	unsafeNameColumn := expr.StringColumn{ColBase: expr.ColBase{TableAlias: "users", ColName: unsafe}}
+	validIntColumn := expr.IntColumn{ColBase: expr.ColBase{TableAlias: "users", ColName: "age"}}
+	validRow := identifierRow{Name: "sensitive-value"}
+
+	cases := []struct {
+		name      string
+		builder   query.Builder
+		untrusted string
+	}{
+		{name: "select_source_alias", builder: query.Select().From(unsafeAliasTable), untrusted: unsafe},
+		{name: "join_source_alias", builder: query.Select().From(validTable).InnerJoin(unsafeAliasTable, expr.Raw("TRUE")), untrusted: unsafe},
+		{name: "cte_name", builder: query.Select().With(unsafe, query.Select().From(validTable)).From(validTable), untrusted: unsafe},
+		{name: "cte_reference", builder: query.Select().From(query.CTERef(unsafe)), untrusted: unsafe},
+		{name: "subquery_alias", builder: query.Select().From(query.FromSubquery(query.Select().From(validTable), unsafe)), untrusted: unsafe},
+		{name: "column_table", builder: query.Select(unsafeTableColumn).From(validTable), untrusted: unsafe},
+		{name: "column_name", builder: query.Select(unsafeNameColumn).From(validTable), untrusted: unsafe},
+		{name: "column_alias", builder: query.Select(expr.ColAs(validColumn, unsafe)).From(validTable), untrusted: unsafe},
+		{name: "aggregate_alias", builder: query.Select(expr.Count().As(unsafe)).From(validTable), untrusted: unsafe},
+		{name: "window_alias", builder: query.Select(expr.RowNumber().As(unsafe)).From(validTable), untrusted: unsafe},
+		{name: "function_alias", builder: query.Select(expr.TsRank(validColumn, expr.ToTsquery("sensitive-value")).As(unsafe)).From(validTable), untrusted: unsafe},
+		{name: "arithmetic_alias", builder: query.Select(validIntColumn.Add(1).As(unsafe)).From(validTable), untrusted: unsafe},
+		{name: "case_alias", builder: query.Select(expr.Case().When(expr.Raw("TRUE"), expr.Lit("sensitive-value")).As(unsafe)).From(validTable), untrusted: unsafe},
+		{name: "simple_case_alias", builder: query.Select(expr.SimpleCase(validColumn).WhenVal("sensitive-value", expr.Lit("matched")).As(unsafe)).From(validTable), untrusted: unsafe},
+		{name: "text_search_alias", builder: query.Select(expr.ToTsvector(validColumn).As(unsafe)).From(validTable), untrusted: unsafe},
+		{name: "distinct_on", builder: query.Select(validColumn).DistinctOn(unsafeNameColumn).From(validTable), untrusted: unsafe},
+		{name: "group_by", builder: query.Select(validColumn).From(validTable).GroupBy(unsafeNameColumn), untrusted: unsafe},
+		{name: "order_by", builder: query.Select(validColumn).From(validTable).OrderBy(unsafeNameColumn.Asc()), untrusted: unsafe},
+		{name: "insert_source_alias", builder: query.InsertInto(unsafeAliasTable).Values(validRow), untrusted: unsafe},
+		{name: "insert_column", builder: query.InsertInto(validTable).Values(dottedIdentifierRow{}), untrusted: "unsafe.identifier"},
+		{name: "conflict_column", builder: query.InsertInto(validTable).Values(validRow).OnConflict(unsafe).DoNothing(), untrusted: unsafe},
+		{name: "conflict_constraint", builder: query.InsertInto(validTable).Values(validRow).OnConflictConstraint(unsafe).DoNothing(), untrusted: unsafe},
+		{name: "upsert_set", builder: query.InsertInto(validTable).Values(validRow).OnConflict("name").DoUpdateSet(unsafe, "sensitive-value"), untrusted: unsafe},
+		{name: "upsert_excluded", builder: query.InsertInto(validTable).Values(validRow).OnConflict("name").DoUpdateSetExcluded(unsafe), untrusted: unsafe},
+		{name: "insert_returning", builder: query.InsertInto(validTable).Values(validRow).Returning(unsafeNameColumn), untrusted: unsafe},
+		{name: "update_source_alias", builder: query.Update(unsafeAliasTable).Set("name", "sensitive-value"), untrusted: unsafe},
+		{name: "update_set", builder: query.Update(validTable).Set(unsafe, "sensitive-value"), untrusted: unsafe},
+		{name: "update_struct", builder: query.Update(validTable).SetStruct(dottedIdentifierRow{}), untrusted: "unsafe.identifier"},
+		{name: "update_returning", builder: query.Update(validTable).Set("name", "sensitive-value").Returning(unsafeNameColumn), untrusted: unsafe},
+		{name: "delete_source_alias", builder: query.DeleteFrom(unsafeAliasTable), untrusted: unsafe},
+		{name: "delete_returning", builder: query.DeleteFrom(validTable).Returning(unsafeNameColumn), untrusted: unsafe},
+		{name: "set_operation_order", builder: query.Select(validColumn).From(validTable).
+			Union(query.Select(validColumn).From(validTable)).OrderBy(unsafeNameColumn.Asc()), untrusted: unsafe},
+	}
+
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			assertInvalidIdentifierBuild(t, test.builder, dialect.Postgres, test.untrusted)
+		})
+	}
+}
+
+func TestBuild_ValidEmbeddedIdentifierQuotesAreEscapedByDialect(t *testing.T) {
+	tests := []struct {
+		name   string
+		d      dialect.Dialect
+		table  string
+		alias  string
+		column string
+		want   string
+	}{
+		{name: "postgres", d: dialect.Postgres, table: `ta"ble`, alias: `al"ias`, column: `co"l`, want: `SELECT "al""ias"."co""l" FROM "ta""ble" AS "al""ias"`},
+		{name: "sqlite", d: dialect.SQLite, table: `ta"ble`, alias: `al"ias`, column: `co"l`, want: `SELECT "al""ias"."co""l" FROM "ta""ble" AS "al""ias"`},
+		{name: "mysql", d: dialect.MySQL, table: "ta`ble", alias: "al`ias", column: "co`l", want: "SELECT `al``ias`.`co``l` FROM `ta``ble` AS `al``ias`"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			table := identifierTable{name: test.table, alias: test.alias}
+			column := expr.StringColumn{ColBase: expr.ColBase{TableAlias: test.alias, ColName: test.column}}
+			sql, args, err := query.Select(column).From(table).Build(test.d)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if sql != test.want || args != nil {
+				t.Fatalf("Build() = (%q, %v), want (%q, nil)", sql, args, test.want)
+			}
+		})
+	}
+}
+
+func assertInvalidIdentifierBuild(t *testing.T, builder query.Builder, d dialect.Dialect, untrusted string) {
+	t.Helper()
+	sql, args, err := builder.Build(d)
+	if sql != "" || args != nil {
+		t.Fatalf("Build() = (%q, %v, %v), want empty SQL and nil args", sql, args, err)
+	}
+	if !errors.Is(err, query.ErrInvalidIdentifier) {
+		t.Fatalf("error = %v, want ErrInvalidIdentifier", err)
+	}
+	rendered := err.Error()
+	if untrusted != "" && strings.Contains(rendered, untrusted) {
+		t.Fatalf("error leaked untrusted identifier %q: %q", untrusted, err)
+	}
+	if strings.ContainsAny(rendered, "\x00\x01\n\r\x7f\u0085\x1b") {
+		t.Fatalf("error contains unsafe control characters: %q", err)
+	}
+}

--- a/query/query.go
+++ b/query/query.go
@@ -140,5 +140,18 @@ func quoteTableSource(ctx *expr.BuildContext, table TableSource) (string, error)
 	if isNilValue(table) {
 		return "", NewError(CodeBuildValidation, "render_table_source", "table source is nil")
 	}
-	return ctx.Quote(table.GrizTableName())
+	name := table.GrizTableName()
+	quotedName, err := ctx.Quote(name)
+	if err != nil {
+		return "", err
+	}
+	if alias := table.GrizTableAlias(); alias != name {
+		// Mutation builders currently render only the base table name, but an
+		// alias is still identifier metadata supplied by the source. Validate it
+		// here so INSERT, UPDATE, and DELETE cannot silently accept unsafe aliases.
+		if _, err := ctx.Quote(alias); err != nil {
+			return "", err
+		}
+	}
+	return quotedName, nil
 }


### PR DESCRIPTION
## Summary

- validate both the base table name and alias in the shared table-source rendering path, including INSERT, UPDATE, and DELETE paths that do not currently render aliases
- add fail-closed conformance coverage for empty, dotted, NUL, LF/CR, DEL, C0, and C1 identifier parts across SELECT, INSERT, UPDATE, DELETE, and set operations
- cover identifier-bearing CTE, subquery, join, column, expression-alias, conflict, assignment, RETURNING, and ordering surfaces
- prove PostgreSQL/SQLite double-quote escaping and MySQL backtick escaping for valid identifiers
- verify normal builds and pgx prepare/register paths preserve `invalid_identifier`, redact unsafe input, publish no SQL/arguments, and do not mutate registries

## Root cause

The error-returning build cutover centralized identifier validation in `BuildContext.Quote`, but `quoteTableSource` only validated `GrizTableName`. SELECT rendered and validated aliases separately; mutation builders ignored aliases, allowing unsafe alias metadata to pass a successful build. The shared helper now validates both identity fields before any builder can succeed.

## Validation

- `go vet ./...` with Go 1.25 and Go 1.26
- `go test -race -count=1 ./...` with Go 1.25 and Go 1.26
- `golangci-lint v2.11.3` — 0 issues
- targeted identifier regressions repeated 20 times
- security, architecture/spec, and senior Go engineer agent reviews — approved with no findings
- `git diff --check`

The documentation build remains blocked on a pre-existing link-check failure introduced on `main`; follow-up #467 tracks it separately.

Closes #412
